### PR TITLE
Set npm as the package ecosystem for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds initial configuration for Dependabot to automate dependency updates for the project. The configuration specifies that npm dependencies will be checked and updated on a weekly schedule.

Dependabot setup:

* Added a new `.github/dependabot.yml` file to enable weekly automated updates for npm dependencies.