### PR TITLE
OZLOGGER fix: isolate event dispatch so a handler throw cannot crash the host (A1)

### DIFF
--- a/lib/util/Events.ts
+++ b/lib/util/Events.ts
@@ -25,7 +25,17 @@ function attachProcessMessageListener(): void {
 		if (!handlers?.size) return;
 
 		for (const registered of handlers) {
-			registered.handler.call(registered.context, data);
+			// A logging event handler must never crash the host process.
+			// Isolate each handler so a throw does not become an uncaught
+			// exception on 'message' nor stop the remaining handlers.
+			try {
+				registered.handler.call(registered.context, data);
+			} catch (e) {
+				console.error(
+					'[OZLogger] event handler threw and was ignored:',
+					e
+				);
+			}
 		}
 	};
 

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -144,6 +144,42 @@ describe('Events', () => {
 			// Calling twice should be a no-op
 			unregister();
 		});
+
+		test('should not crash the process when a handler throws and should still run the others', () => {
+			const ctx = {} as unknown as Logger;
+			const throwing = jest.fn(() => {
+				throw new Error('handler boom');
+			});
+			const other = jest.fn();
+
+			// Silence the expected console.error from the isolated handler.
+			const errSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			const unregisterThrowing = registerEvent(
+				ctx,
+				'guarded.event',
+				throwing
+			);
+			const unregisterOther = registerEvent(ctx, 'guarded.event', other);
+
+			expect(() =>
+				process.emit(
+					'message' as NodeJS.Signals,
+					{ event: 'guarded.event' } as unknown as NodeJS.Signals
+				)
+			).not.toThrow();
+
+			expect(throwing).toHaveBeenCalledTimes(1);
+			// A throwing handler must not prevent the remaining ones from running.
+			expect(other).toHaveBeenCalledTimes(1);
+			expect(errSpy).toHaveBeenCalledTimes(1);
+
+			errSpy.mockRestore();
+			unregisterThrowing();
+			unregisterOther();
+		});
 	});
 });
 


### PR DESCRIPTION
## A1 — Isolar o dispatch de eventos para não derrubar o host

Origem: ponto **A1** do review da PR #83 (release 0.3.0).

### Problema
Em `lib/util/Events.ts`, o laço que chama os handlers registrados (`registered.handler.call(...)`) não tinha tratamento de erro. Esse laço roda dentro do listener de `process('message')`, que é disparado inclusive em apps não clusterizados (via `broadcastEvent`, que usa `process.emit('message')`).

Se qualquer handler lançar:
- a exceção sobe como **exceção não tratada** no `process('message')` e pode **encerrar o processo do app**;
- o laço é interrompido, então os **demais loggers não recebem o evento**.

### Correção
Cada `handler.call(...)` passa a rodar dentro de `try/catch`. Um handler que lance é registrado via `console.error` e ignorado, e os handlers seguintes continuam executando. Um logger nunca deve derrubar o app que o utiliza.

### Testes
Adicionado teste em `tests/events.test.ts`: um handler que lança não derruba o `process.emit('message')`, o handler seguinte ainda é chamado e o erro é logado uma vez.

- `tsc --noEmit`: sem erros
- Suíte completa: 217 testes passando, cobertura global 95.67% statements / 96.53% lines (acima do gate de 95%)
