### PR TITLE
OZLOGGER fix: guard log wrappers so a failing client cannot crash the caller (A2)

### DIFF
--- a/lib/format/json.ts
+++ b/lib/format/json.ts
@@ -77,12 +77,19 @@ export function json<TScope extends Logger>(
 	const paint = colorized();
 
 	return (level: LevelTag, ...args: unknown[]) => {
-		const payload = toStructuredJsonLog.call(this, level, now, tag);
+		// A log call must never throw into the caller's business logic, so we
+		// isolate serialization and the underlying (possibly app-provided)
+		// client behind a try/catch.
+		try {
+			const payload = toStructuredJsonLog.call(this, level, now, tag);
 
-		for (const arg of args) {
-			payload.push(normalize(arg));
+			for (const arg of args) {
+				payload.push(normalize(arg));
+			}
+
+			logger.log(paint[level](payload.toString()));
+		} catch (e) {
+			console.error('[OZLogger] failed to emit log:', e);
 		}
-
-		logger.log(paint[level](payload.toString()));
 	};
 }

--- a/lib/format/text.ts
+++ b/lib/format/text.ts
@@ -20,8 +20,15 @@ export function text<TScope extends Logger>(
 	const paint = colorized();
 
 	return (level: LevelTag, ...args: unknown[]) => {
-		const data = args.map((arg) => stringify(arg)).join(' ');
+		// A log call must never throw into the caller's business logic, so we
+		// isolate serialization and the underlying (possibly app-provided)
+		// client behind a try/catch.
+		try {
+			const data = args.map((arg) => stringify(arg)).join(' ');
 
-		logger.log(paint[level](`${now()}[${level}] ${tag ?? ''} ${data}`));
+			logger.log(paint[level](`${now()}[${level}] ${tag ?? ''} ${data}`));
+		} catch (e) {
+			console.error('[OZLogger] failed to emit log:', e);
+		}
 	};
 }

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,4 +1,11 @@
-import { expect, describe, test, beforeEach, afterEach } from '@jest/globals';
+import {
+	expect,
+	describe,
+	test,
+	beforeEach,
+	afterEach,
+	jest
+} from '@jest/globals';
 import createLogger, { Logger } from '../lib';
 
 describe('JSON Formatter', () => {
@@ -336,5 +343,56 @@ describe('JSON Formatter error handling', () => {
 
 		delete process.env.OZLOGGER_OUTPUT;
 		delete process.env.OZLOGGER_LEVEL;
+	});
+});
+
+describe('Log call must never throw into the caller', () => {
+	const failingClient = {
+		log: () => {
+			throw new Error('client boom');
+		}
+	};
+
+	afterEach(() => {
+		delete process.env.OZLOGGER_OUTPUT;
+		delete process.env.OZLOGGER_LEVEL;
+	});
+
+	test('json: a throwing client does not propagate to the caller', () => {
+		process.env.OZLOGGER_OUTPUT = 'json';
+		process.env.OZLOGGER_LEVEL = 'debug';
+
+		const logger = createLogger('JSON-THROW', {
+			client: failingClient,
+			noServer: true
+		});
+
+		const errSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		expect(() => logger.info('boom')).not.toThrow();
+		expect(errSpy).toHaveBeenCalledTimes(1);
+
+		errSpy.mockRestore();
+	});
+
+	test('text: a throwing client does not propagate to the caller', () => {
+		process.env.OZLOGGER_OUTPUT = 'text';
+		process.env.OZLOGGER_LEVEL = 'debug';
+
+		const logger = createLogger('TEXT-THROW', {
+			client: failingClient,
+			noServer: true
+		});
+
+		const errSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		expect(() => logger.info('boom')).not.toThrow();
+		expect(errSpy).toHaveBeenCalledTimes(1);
+
+		errSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
## A2 — Um logger nunca deve lançar a partir de uma chamada de log

Origem: ponto **A2** do review da PR #83 (release 0.3.0).

### Problema
Os wrappers de formatação (`lib/format/json.ts` e `lib/format/text.ts`) montavam a mensagem e chamavam `logger.log(...)` sem `try/catch`. Como os apps podem injetar o próprio `client` (`AbstractLogger`), se esse client lançar — ou se a serialização (`normalize`/`stringify`) tropeçar num objeto problemático (ex.: getter que lança) — a exceção sobe de forma síncrona para a linha que chamou `logger.info(...)` e derruba a lógica de negócio de quem usa o logger.

A remoção do `async` dos wrappers (release 0.3.0) tornou isso mais direto: antes a exceção virava rejeição de promise; agora propaga síncrona ao chamador.

### Correção
O corpo de cada wrapper passa a rodar dentro de `try/catch`. Qualquer falha (serialização ou client) é registrada via `console.error` e nunca propaga para o chamador.

### Testes
Adicionados em `tests/format.test.ts` (bloco "Log call must never throw into the caller"): com um `client` cujo `log` lança, tanto no modo `json` quanto `text`, `logger.info(...)` não lança e o erro é registrado uma vez.

- `tsc --noEmit`: sem erros
- Suíte completa: 218 testes passando; `json.ts` e `text.ts` com 100% de statements/lines; cobertura global 95.69% statements / 96.55% lines (acima do gate de 95%)
