### PR TITLE
OZLOGGER feat: restrict audit to a single argument with VictoriaLogs size limit

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -65,7 +65,7 @@ block-beta
 |--------|-----------|
 | `debug()` | Logs de depuração (severity: 5) |
 | `info()` | Logs informativos (severity: 9) |
-| `audit()` | Logs de auditoria (severity: 12) |
+| `audit(data)` | Auditoria p/ VictoriaLogs — um único argumento (severity: 12) |
 | `warn()` | Logs de aviso (severity: 13) |
 | `error()` | Logs de erro (severity: 17) |
 | `time()` | Inicia um timer para medição |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ A saída JSON do OZLogger é compatível com:
 | AWS CloudWatch | Via CloudWatch Agent |
 | Google Cloud Logging | Via Logging Agent |
 | Grafana Loki | Via Promtail |
+| VictoriaLogs | Direta via stdout (alvo principal do nível `audit`) |
+| SigNoz | Via OpenTelemetry Collector |
+
+> Para bases indexadas por labels (VictoriaLogs, Loki, SigNoz), veja as boas práticas em [Auditoria e bases de logs](#auditoria-e-bases-de-logs-victorialogs--loki--signoz) antes de modelar o que vai no `audit`.
 
 ---
 
@@ -391,12 +395,23 @@ Níveis deprecados (serão removidos em 0.3.x):
 ### Métodos de Logging
 
 ```typescript
-logger.debug(...args: unknown[]): void  // Nível DEBUG
-logger.info(...args: unknown[]): void   // Nível INFO
-logger.audit(...args: unknown[]): void  // Nível AUDIT
-logger.warn(...args: unknown[]): void   // Nível WARNING
-logger.error(...args: unknown[]): void  // Nível ERROR
+logger.debug(...args: unknown[]): void   // Nível DEBUG
+logger.info(...args: unknown[]): void    // Nível INFO
+logger.audit(data: unknown): void        // Nível AUDIT — apenas UM argumento (qualquer tipo)
+logger.warn(...args: unknown[]): void    // Nível WARNING
+logger.error(...args: unknown[]): void   // Nível ERROR
 ```
+
+> **Sobre o `audit`:** diferente dos demais métodos (que herdaram o estilo `console.log(a, b, c)`), o `audit()` é o ponto de entrada para o **VictoriaLogs** e aceita **exatamente um argumento** — de qualquer tipo (objeto, string, número, etc.), escrito como está no stdout para ingestão. Ele não faz parsing nem trata múltiplos argumentos. Chamar `audit()` com um número de argumentos diferente de um **lança um erro** (é erro de programação, deve aparecer em dev/test). Um body acima do limite seguro, ou que não seja serializável, é **descartado com um log de ERROR**, sem derrubar o processo. Para bases indexadas, prefira enviar um objeto com labels bem definidos (veja abaixo).
+
+### Auditoria e bases de logs (VictoriaLogs / Loki / SigNoz)
+
+O `audit` foi pensado para alimentar bases de logs indexadas (VictoriaLogs, Loki, SigNoz). Para que a indexação e os dashboards funcionem bem, siga estas práticas:
+
+- **Use labels/campos bem definidos e estáveis.** Essas bases indexam por labels/campos. Prefira um conjunto pequeno e consistente de chaves (ex.: `action`, `entity`, `entityId`, `userId`, `result`) em vez de chaves dinâmicas ou ilimitadas. Labels de alta cardinalidade (um valor diferente de chave por requisição) degradam a indexação e o desempenho das consultas.
+- **Não inclua dados que já são gerados automaticamente.** Não coloque `timestamp`, `traceId`, `spanId`, `pid`, `ppid`, `severity`/`level` nem o `tag` dentro do objeto do `audit`. Esses campos já são adicionados pelo próprio logger (contexto, severidade e timestamp) e/ou pelo VictoriaLogs no momento da ingestão. Duplicá-los gera conflito, ruído e ocupa espaço à toa.
+- **Mantenha o body pequeno.** O VictoriaLogs descarta linhas acima de `-insert.maxLineSizeBytes` (256KB por padrão) e trata registros próximos de 2MB de forma ineficiente. O OZLogger limita o body do `audit` a **256KB** (`DEFAULT_AUDIT_MAX_BYTES`); acima disso o registro é descartado e um ERROR é logado. Audite apenas o que é relevante para a trilha de auditoria — não envie payloads inteiros de requisição/resposta.
+- **Envie dados estruturados, não strings concatenadas.** Como o destino indexa por campos, prefira `logger.audit({ action: 'login', userId: 42 })` a `logger.audit({ msg: 'login user 42' })`.
 
 ### Métodos de Timing
 

--- a/docs/QUICK-GUIDE.md
+++ b/docs/QUICK-GUIDE.md
@@ -47,7 +47,7 @@ const logger = createLogger('MeuApp');
 // Métodos de log disponíveis
 logger.debug('Mensagem de debug');
 logger.info('Mensagem informativa');
-logger.audit('Ação de auditoria');
+logger.audit({ action: 'recurso_acessado' }); // um único argumento
 logger.warn('Aviso importante');
 logger.error('Erro encontrado');
 ```
@@ -96,8 +96,8 @@ logger.debug('Query executada', { sql: 'SELECT * FROM users', time: '15ms' });
 // INFO - Eventos normais do sistema
 logger.info('Servidor iniciado na porta 3000');
 
-// AUDIT - Ações que precisam ser rastreadas
-logger.audit('Usuário logou', { userId: 123, ip: '192.168.1.1' });
+// AUDIT - Ações que precisam ser rastreadas (um único objeto JSON)
+logger.audit({ action: 'user_login', userId: 123, ip: '192.168.1.1' });
 
 // WARN - Situações potencialmente problemáticas
 logger.warn('Cache miss para chave', { key: 'user:123' });
@@ -105,6 +105,8 @@ logger.warn('Cache miss para chave', { key: 'user:123' });
 // ERROR - Erros que precisam de atenção
 logger.error('Falha na conexão com banco', new Error('Connection timeout'));
 ```
+
+> **`audit` é especial:** recebe **um único argumento** (de qualquer tipo, idealmente um objeto com labels) e é o canal de auditoria para o **VictoriaLogs**. Passar mais de um argumento lança erro. Não inclua `timestamp`/`traceId`/`pid` no objeto — já são adicionados automaticamente pelo logger e/ou pelo VictoriaLogs. Um body acima de 256KB é descartado com um ERROR. Veja as boas práticas no [README](../README.md#auditoria-e-bases-de-logs-victorialogs--loki--signoz).
 
 ### Configurar Nível Mínimo
 
@@ -244,7 +246,7 @@ app.get('/users/:id', async (req, res) => {
     
     try {
         const user = await findUser(req.params.id);
-        req.logger.audit('Usuário encontrado', { userId: req.params.id });
+        req.logger.audit({ action: 'user_found', userId: req.params.id });
         res.json(user);
     } catch (error) {
         req.logger.error('Erro ao buscar usuário', error);
@@ -325,7 +327,7 @@ function logUserAction(user: User, action: string) {
     // Depois mascarar campos sensíveis
     const safe = mask(filtered, ['password', 'cpf', 'creditCard']);
     
-    logger.audit(action, { user: safe });
+    logger.audit({ action, user: safe });
 }
 ```
 
@@ -586,8 +588,9 @@ function auditUserAction(
     user: User,
     details: Record<string, unknown>
 ) {
-    logger.audit(action, {
-        timestamp: new Date().toISOString(),
+    // Um único objeto. Não inclua timestamp/traceId/etc — já são
+    // adicionados pelo logger e/ou pelo VictoriaLogs na ingestão.
+    logger.audit({
         actor: {
             id: user.id,
             email: mask({ email: user.email }, ['email']).email,

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,6 +1,10 @@
 import { LogWrapper } from './util/type/LogWrapper';
 import { AbstractLogger } from './util/type/AbstractLogger';
-import { LogMethod, LoggerMethods } from './util/interface/LoggerMethods';
+import {
+	LogMethod,
+	AuditMethod,
+	LoggerMethods
+} from './util/interface/LoggerMethods';
 import { LogContext } from './util/interface/LogContext';
 import { LogLevels } from './util/enum/LogLevels';
 import { LevelTag } from './util/enum/LevelTags';
@@ -8,7 +12,13 @@ import { Server } from 'http';
 import { getLogWrapper } from './format';
 import { registerEvent } from './util/Events';
 import { setupLogServer } from './http/server';
-import { level, output, host, getProcessInformation } from './util/Helpers';
+import {
+	level,
+	output,
+	host,
+	getProcessInformation,
+	getCircularReplacer
+} from './util/Helpers';
 import { context, trace } from '@opentelemetry/api';
 
 /**
@@ -20,6 +30,17 @@ const DEFAULT_TIMER_TTL = 600000;
  * Default timer cleanup interval in milliseconds (1 minute).
  */
 const DEFAULT_TIMER_GC_INTERVAL = 60000;
+
+/**
+ * Maximum serialized size, in bytes, allowed for an audit body.
+ *
+ * VictoriaLogs skips log lines larger than its `-insert.maxLineSizeBytes`
+ * (256KB by default) during ingestion, and handles records approaching the
+ * hardcoded 2MB ceiling inefficiently. We cap the audit body at that 256KB
+ * line limit so a single audit entry never floods VictoriaLogs; bodies above
+ * it are dropped with an error.
+ */
+const DEFAULT_AUDIT_MAX_BYTES = 256 * 1024;
 
 /**
  * Logger module class.
@@ -230,6 +251,73 @@ export class Logger implements LoggerMethods {
 	}
 
 	/**
+	 * Factory method for the audit logging method.
+	 *
+	 * Audit is the VictoriaLogs ingestion entrypoint, so it is intentionally
+	 * stricter than the other log methods: it accepts exactly one value (of any
+	 * type). Passing a different number of arguments is a programming error and
+	 * throws, regardless of the active level, so it is caught in dev/test. An
+	 * oversized or unserializable body is a runtime data problem: it is reported
+	 * via this.error() and dropped, never crashing the host nor flooding
+	 * VictoriaLogs.
+	 *
+	 * @param   enabled  If the audit level is enabled for the current level.
+	 * @returns The audit logging function.
+	 */
+	private buildAudit(enabled: boolean): AuditMethod {
+		const fn = (...args: unknown[]): void => {
+			// Audit takes exactly one value (of any type). Passing a different
+			// number of arguments is a programming error and throws, regardless
+			// of level, so it surfaces even when audit is disabled.
+			if (args.length !== 1) {
+				throw new Error(
+					`audit() expects exactly one argument, but received ${args.length}`
+				);
+			}
+
+			const data = args[0];
+
+			if (!enabled) return;
+
+			let serialized: string | undefined;
+			try {
+				serialized = JSON.stringify(data, getCircularReplacer());
+			} catch (e) {
+				this.error(
+					'[OZLogger] audit() could not serialize the provided value; record dropped',
+					e
+				);
+				return;
+			}
+
+			// JSON.stringify yields undefined for values such as undefined or
+			// functions; treat those as empty for the size check.
+			const size = Buffer.byteLength(serialized ?? '', 'utf8');
+			if (size > DEFAULT_AUDIT_MAX_BYTES) {
+				this.error(
+					`[OZLogger] audit() body of ${size} bytes exceeds the safe limit of ${DEFAULT_AUDIT_MAX_BYTES} bytes for VictoriaLogs ingestion; record dropped`
+				);
+				return;
+			}
+
+			this.logger('AUDIT', data);
+		};
+
+		const timeEnd = !enabled
+			? (id: string) => {
+					// We must cleanup the timer even if we don't log
+					if (this.timers.has(id)) this.timers.delete(id);
+					return this;
+				}
+			: (id: string) => {
+					this.logger('AUDIT', `${id}: ${this.getTime(id)} ms`);
+					return this;
+				};
+
+		return Object.assign(fn, { timeEnd });
+	}
+
+	/**
 	 * Method for handling scheduling logger tasks.
 	 *
 	 * @param   id        The task identifier.
@@ -266,7 +354,7 @@ export class Logger implements LoggerMethods {
 		this.critical = this.toggle(LogLevels['critical'] >= lvl, 'CRITICAL');
 		this.error = this.toggle(LogLevels['error'] >= lvl, 'ERROR');
 		this.warn = this.toggle(LogLevels['warn'] >= lvl, 'WARNING');
-		this.audit = this.toggle(LogLevels['audit'] >= lvl, 'AUDIT');
+		this.audit = this.buildAudit(LogLevels['audit'] >= lvl);
 		this.info = this.toggle(LogLevels['info'] >= lvl, 'INFO');
 		this.http = this.toggle(LogLevels['http'] >= lvl, 'HTTP');
 		this.debug = this.toggle(LogLevels['debug'] >= lvl, 'DEBUG');
@@ -431,9 +519,14 @@ export class Logger implements LoggerMethods {
 	/**
 	 * Audit logging method.
 	 *
-	 * @param   args  Data to be logged.
+	 * Entrypoint for VictoriaLogs ingestion. Accepts exactly one argument of any
+	 * type, written as-is to stdout. Passing a different number of arguments
+	 * throws; an oversized body (over {@link DEFAULT_AUDIT_MAX_BYTES}) is dropped
+	 * with an error.
+	 *
+	 * @param   data  The single value to be audited.
 	 */
-	public audit: LogMethod;
+	public audit: AuditMethod;
 
 	/**
 	 * HTTP request logging method. Same as '.info()'.

--- a/lib/util/interface/LoggerMethods.ts
+++ b/lib/util/interface/LoggerMethods.ts
@@ -6,10 +6,24 @@ export type LogMethod = ((...args: unknown[]) => void) & {
 	timeEnd(id: string): Logger;
 };
 
+/**
+ * Audit logging method.
+ *
+ * Unlike the other log methods, audit() is the entrypoint for VictoriaLogs
+ * ingestion and accepts exactly ONE argument — of any type (object, string,
+ * number, etc.). Calling it with a different number of arguments throws, since
+ * that is a programming error and should surface in dev/test. The attached
+ * timeEnd() preserves the timer helper available on the other methods.
+ */
+export type AuditMethod = ((data: unknown) => void) & {
+	timeEnd(id: string): Logger;
+};
+
 export interface LoggerMethods extends Record<
-	keyof Omit<typeof LogLevels, 'quiet'>,
+	keyof Omit<typeof LogLevels, 'quiet' | 'audit'>,
 	LogMethod
 > {
+	audit: AuditMethod;
 	time(id: string): Logger;
 	timeEnd(id: string): Logger;
 	withContext(ctx: LogContext): Logger;

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,132 @@
+import { expect, describe, test, beforeEach, afterEach } from '@jest/globals';
+import createLogger, { Logger } from '../lib';
+
+describe('audit (VictoriaLogs ingestion contract)', () => {
+	let logger: Logger;
+	let logged: string[] = [];
+	const mockLogger = { log: (msg: string) => logged.push(msg) };
+
+	beforeEach(() => {
+		logged = [];
+		process.env.OZLOGGER_OUTPUT = 'json';
+		process.env.OZLOGGER_LEVEL = 'audit';
+		logger = createLogger('AUDIT-TEST', {
+			client: mockLogger,
+			noServer: true
+		});
+	});
+
+	afterEach(() => {
+		delete process.env.OZLOGGER_OUTPUT;
+		delete process.env.OZLOGGER_LEVEL;
+	});
+
+	describe('valid usage', () => {
+		test('writes a single JSON object as the audit body', () => {
+			logger.audit({ user: 'alice', action: 'login' });
+
+			expect(logged.length).toBe(1);
+			const output = JSON.parse(logged[0]);
+			expect(output.severityText).toBe('AUDIT');
+			expect(output.body['0']).toEqual({
+				user: 'alice',
+				action: 'login'
+			});
+		});
+
+		test('serializes objects with circular references', () => {
+			const data: Record<string, unknown> = { id: 1 };
+			data.self = data;
+
+			expect(() => logger.audit(data)).not.toThrow();
+			expect(logged.length).toBe(1);
+			expect(JSON.parse(logged[0]).severityText).toBe('AUDIT');
+		});
+
+		test('accepts a single value of any type (string, number, array)', () => {
+			logger.audit('a plain string');
+			logger.audit(42);
+			logger.audit([1, 2, 3]);
+
+			expect(logged.length).toBe(3);
+			expect(JSON.parse(logged[0]).body['0']).toBe('a plain string');
+			expect(JSON.parse(logged[1]).body['0']).toBe(42);
+			expect(JSON.parse(logged[2]).body['0']).toEqual([1, 2, 3]);
+		});
+	});
+
+	describe('usage errors throw (programming mistakes)', () => {
+		test('throws when called with no arguments', () => {
+			// @ts-expect-error - testing invalid input
+			expect(() => logger.audit()).toThrow(/exactly one argument/);
+			expect(logged.length).toBe(0);
+		});
+
+		test('throws when called with more than one argument', () => {
+			// @ts-expect-error - testing invalid input
+			expect(() => logger.audit({ a: 1 }, { b: 2 })).toThrow(
+				/exactly one argument/
+			);
+			expect(logged.length).toBe(0);
+		});
+
+		test('throws (arg count) even when the audit level is disabled', () => {
+			logger.changeLevel('error');
+			logged = [];
+
+			// @ts-expect-error - testing invalid input
+			expect(() => logger.audit('a', 'b')).toThrow(
+				/exactly one argument/
+			);
+			// A valid single value is simply not emitted while disabled.
+			expect(() => logger.audit({ ok: true })).not.toThrow();
+			expect(logged.length).toBe(0);
+		});
+	});
+
+	describe('runtime data problems are dropped with an error (never crash)', () => {
+		test('drops an oversized body and logs an error', () => {
+			const huge = { blob: 'x'.repeat(300 * 1024) };
+
+			expect(() => logger.audit(huge)).not.toThrow();
+
+			// The audit record is dropped; only the error log is emitted.
+			expect(logged.length).toBe(1);
+			const output = JSON.parse(logged[0]);
+			expect(output.severityText).toBe('ERROR');
+			expect(output.body['0']).toContain('exceeds the safe limit');
+		});
+
+		test('drops an unserializable body and logs an error', () => {
+			// BigInt is a valid Record value at the type level but cannot be
+			// serialized by JSON.stringify, so it fails at runtime.
+			const bad = { value: BigInt(9007199254740991) };
+
+			expect(() => logger.audit(bad)).not.toThrow();
+
+			expect(logged.length).toBe(1);
+			const output = JSON.parse(logged[0]);
+			expect(output.severityText).toBe('ERROR');
+			expect(output.body['0']).toContain('could not serialize');
+		});
+	});
+
+	describe('timer helper remains available', () => {
+		test('audit.timeEnd logs the elapsed time at audit level', () => {
+			logger.time('audit-op');
+			logger.audit.timeEnd('audit-op');
+
+			expect(logged.length).toBe(1);
+			expect(JSON.parse(logged[0]).severityText).toBe('AUDIT');
+		});
+
+		test('audit.timeEnd cleans up the timer when audit is disabled', () => {
+			logger.changeLevel('error');
+			logged = [];
+
+			logger.time('audit-op');
+			expect(() => logger.audit.timeEnd('audit-op')).not.toThrow();
+			expect(logged.length).toBe(0);
+		});
+	});
+});

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -123,7 +123,7 @@ describe('JSON Formatter', () => {
 		});
 
 		test('audit level', () => {
-			logger.audit('audit msg');
+			logger.audit({ msg: 'audit msg' });
 			const output = JSON.parse(logged[0]);
 			expect(output.severityText).toBe('AUDIT');
 			expect(output.severityNumber).toBe(12);

--- a/tests/logger-core.test.ts
+++ b/tests/logger-core.test.ts
@@ -188,7 +188,7 @@ describe('Logger Core', () => {
 			logged = [];
 			logger.debug('no');
 			logger.info('no');
-			logger.audit('no');
+			logger.audit({ m: 'no' });
 			logger.warn('no');
 			expect(logged.length).toBe(0);
 			logger.error('yes');
@@ -202,7 +202,7 @@ describe('Logger Core', () => {
 			logged = [];
 			logger.debug('no');
 			logger.info('no');
-			logger.audit('no');
+			logger.audit({ m: 'no' });
 			logger.warn('no');
 			logger.error('no');
 			expect(logged.length).toBe(0);
@@ -215,7 +215,7 @@ describe('Logger Core', () => {
 			logger.debug('no'); // debug < audit
 			logger.info('no'); // info < audit
 			expect(logged.length).toBe(0);
-			logger.audit('yes');
+			logger.audit({ m: 'yes' });
 			expect(logged.length).toBe(1);
 		});
 	});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -28,7 +28,9 @@ describe('OZLogger factory test suite.', () => {
 
 	test('logger must have audit method.', () => {
 		expect(typeof logger['audit'] === 'function').toBe(true);
-		expect(() => logger.audit('audit message log')).not.toThrow(Error);
+		expect(() =>
+			logger.audit({ message: 'audit message log' })
+		).not.toThrow(Error);
 		logger.time('test');
 		expect(() => logger.audit.timeEnd('test')).not.toThrow(Error);
 	});


### PR DESCRIPTION
## Restringir o `audit` a um único argumento (alvo VictoriaLogs)

### Motivação
Hoje o `audit` recebe múltiplos parâmetros porque herdou o estilo `console.log(a, b, c, d)`. Como queremos usar o `audit` para uma finalidade específica — logar dados direto do stdout para dentro do **VictoriaLogs**, que salva num formato específico para dashboards — não faz mais sentido permitir múltiplos parâmetros nem parsers/complexidade para tratar vários dados.

### O que muda (breaking change)
- `audit()` passa a aceitar **exatamente um argumento**, de **qualquer tipo** (objeto, string, número, array, etc.), escrito como está no stdout. Assinatura: `audit(data: unknown): void`.
- **Erro de uso** (nº de argumentos diferente de 1) → **lança erro** (é erro de programação; aparece em dev/test). Validado inclusive quando o nível `audit` está desabilitado.
- **Problema de dado em runtime** (body acima do limite, ou não serializável) → **descartado com um log de ERROR**, sem derrubar o processo (consistente com o princípio de que o logger nunca derruba o host — PRs #84/#85).
- O helper `audit.timeEnd(id)` é mantido.

### Limite de tamanho do body
O VictoriaLogs descarta linhas acima de `-insert.maxLineSizeBytes` (**256KB** por padrão) na ingestão e trata registros próximos de 2MB de forma ineficiente. Adicionado `DEFAULT_AUDIT_MAX_BYTES = 256KB`, alinhado a esse limite de linha do VictoriaLogs, para que um único registro de auditoria nunca o inunde. Acima disso o registro é descartado e um ERROR é logado.

### Documentação (README)
- Assinatura do `audit` atualizada (`data: unknown`) + nota sobre o contrato (um argumento de qualquer tipo).
- Nova seção **"Auditoria e bases de logs (VictoriaLogs / Loki / SigNoz)"** com boas práticas:
  - usar **labels/campos bem definidos e estáveis** (evitar alta cardinalidade) para boa indexação;
  - **não incluir** no objeto dados já gerados automaticamente (`timestamp`, `traceId`, `spanId`, `pid`, `ppid`, `severity`/`level`, `tag`) — vêm do logger e/ou do VictoriaLogs;
  - manter o **body pequeno** (limite de 256KB);
  - para bases indexadas, **preferir um objeto com labels** em vez de strings concatenadas.
- VictoriaLogs e SigNoz adicionados à tabela de compatibilidade.

### Testes
Novo `tests/audit.test.ts`: objeto válido, referências circulares, **valor de qualquer tipo** (string/número/array), throw por nº de argumentos (0/2, inclusive com nível desabilitado), descarte+ERROR em body grande e não serializável, e `audit.timeEnd`. Testes existentes que passavam múltiplos args ao `audit` foram ajustados.

- `tsc --noEmit`: sem erros
- Suíte completa: **226 testes** passando; cobertura global **95.86% statements / 96.69% lines** (acima do gate de 95%)

Fontes do limite do VictoriaLogs:
- https://docs.victoriametrics.com/victorialogs/faq/
- https://docs.victoriametrics.com/victorialogs/
