### PR TITLE
OZLOGGER fix: #time 5m update npm version command to use npm pkg set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
               run: |
                   TAG="${{ github.event.release.tag_name }}"
                   VERSION="${TAG#v}"
-                  npm version "$VERSION" --no-git-tag-version
+                  npm pkg set version="$VERSION"
 
             - name: Determine dist-tag
               id: dist-tag


### PR DESCRIPTION
## Motivação

Durante a publicação de releases, o workflow utilizava `npm version <version> --no-git-tag-version` para sincronizar a versão do `package.json` com a tag da release.

Entretanto, quando a versão definida na tag já estava presente no `package.json`, o comando falhava com o erro:

`npm ERR! Version not changed`

Isso fazia com que o processo de publicação fosse interrompido mesmo em um cenário válido.

## Alteração

Substituído o uso de:

```bash
npm version "$VERSION" --no-git-tag-version
```

por:

```bash
npm pkg set version="$VERSION"
```

## Benefícios

* Evita falhas desnecessárias quando a versão do `package.json` já corresponde à versão da release.
* Mantém o comportamento esperado de sincronização da versão antes da publicação.
* Torna o processo de release idempotente e mais resiliente.
