### PR TITLE
OZLOGGER feat(audit): util reutilizável de quebra de logs (AuditChunk) (#88)

### DIFF
--- a/docs/rfc/RFC-OZLOGGER-AUDIT-001.md
+++ b/docs/rfc/RFC-OZLOGGER-AUDIT-001.md
@@ -1,0 +1,366 @@
+# RFC OZLOGGER-AUDIT-001 — Padrão de Auditoria do OZLogger
+
+> **Versão:** 1.0 · **Status:** Proposta para revisão da equipe · **Data:** 2026-06-24
+> **Assinatura:** `audit(_msg: string, body: unknown)` · **Destino:** Victoria Logs local (uma instância por cliente, host único)
+
+Este documento define o canal de auditoria do OZLogger: a assinatura `audit(_msg, body)`, o fim do campo `body.0` e a ingestão garantida no Victoria Logs. A quebra de registros grandes é uma **medida de contingência** contra a perda silenciosa de dados, e **não um recurso**. O canal é independente do OpenTelemetry e permanece local, na máquina de cada cliente.
+
+---
+
+## Índice
+
+1. [Sumário executivo](#1-sumário-executivo)
+2. [Objetivos](#2-objetivos)
+3. [Contexto](#3-contexto)
+4. [O problema: registros de auditoria excessivamente grandes](#4-o-problema-registros-de-auditoria-excessivamente-grandes)
+5. [Limites do Victoria Logs e consumo de memória](#5-limites-do-victoria-logs-e-consumo-de-memória)
+6. [Assinatura e estrutura do registro](#6-assinatura-e-estrutura-do-registro)
+7. [Princípio fundamental: auditar a intenção](#7-princípio-fundamental-auditar-a-intenção)
+8. [Contingência: a quebra de registros grandes](#8-contingência-a-quebra-de-registros-grandes)
+9. [Função temporária para a ferramenta de importação](#9-função-temporária-para-a-ferramenta-de-importação)
+10. [Modelagem para consulta](#10-modelagem-para-consulta)
+11. [Consultas (LogsQL)](#11-consultas-logsql)
+12. [Matriz de decisão: conteúdo do corpo](#12-matriz-de-decisão-conteúdo-do-corpo)
+13. [Observabilidade e dados sensíveis](#13-observabilidade-e-dados-sensíveis)
+14. [Consequências](#14-consequências)
+15. [Referências](#15-referências)
+
+---
+
+## 1. Sumário executivo
+
+1. **Assinatura `audit(_msg, body)`.** O primeiro parâmetro é a mensagem (uma string); o segundo é o corpo do registro. A assinatura é fixa, o que encerra o estilo variádico e elimina o campo `body.0`. A mensagem `_msg` passa a ser definida de forma simples e explícita.
+2. **O objetivo principal é auditar a intenção, não os dados expandidos.** Um registro de grande porte costuma indicar uma modelagem inadequada (por exemplo, gravar a consulta com toda a lista de identificadores). Registrar "atualização de N itens correspondentes ao filtro X" mantém o registro pequeno e dispensa qualquer quebra.
+3. **A quebra de registros grandes é uma contingência, não um recurso.** Existe apenas para evitar a perda silenciosa de dados em casos extremos. Sempre que ocorre, emite um **ERROR de alta visibilidade com o `audit_id`**, indicando que a correção deve ser feita na origem. Não deve ser empregada como caminho habitual.
+4. **Função temporária para a ferramenta de importação.** A função `auditChunked()` realiza a quebra em segmentos de até 256 KB enquanto a importação não for ajustada. Está marcada como `@deprecated` e **deve ser removida** assim que a importação passar a auditar por intenção (ver [§9](#9-função-temporária-para-a-ferramenta-de-importação)).
+5. **O canal de auditoria é local e independente do OpenTelemetry.** Os campos `traceId`, `spanId`, `host` e `tenant` são tratados no Fluent Bit, no caminho do SigNoz, e não integram a auditoria. Os campos `severityText` e `severityNumber` são mantidos. Quanto a dados sensíveis, apenas senhas e segredos são redigidos; e-mail, CPF e demais dados pessoais permanecem visíveis.
+
+---
+
+## 2. Objetivos
+
+| Objetivo | Como é atendido |
+| --- | --- |
+| 1 — Assinatura fixa `audit(_msg, body)` | Dois parâmetros; qualquer outra aridade lança erro. Sem estilo variádico e sem `body.0` ([§6](#6-assinatura-e-estrutura-do-registro)). |
+| 2 — Mensagem (`_msg`) simples | É o primeiro parâmetro, sempre uma string explícita ([§6](#6-assinatura-e-estrutura-do-registro)). |
+| 3 — Nenhuma perda silenciosa | A contingência quebra o que exceder o limite e sempre registra um ERROR com o `audit_id` ([§8](#8-contingência-a-quebra-de-registros-grandes)). |
+| 4 — Ingestão estável no Victoria Logs | Linhas de até cerca de 200 KB. O Victoria Logs descarta linhas grandes para preservar memória; manter as linhas abaixo do limite elimina esse risco ([§5](#5-limites-do-victoria-logs-e-consumo-de-memória)). |
+| 5 — Registros pequenos por padrão | Auditar a intenção ([§7](#7-princípio-fundamental-auditar-a-intenção)); a quebra é exceção. |
+| 6 — Facilidade de consulta | Campos planos indexados, rótulos estáveis, `_msg` e o filtro `json_array_contains_any` ([§10](#10-modelagem-para-consulta), [§11](#11-consultas-logsql)). |
+
+---
+
+## 3. Contexto
+
+O OZLogger é um módulo de logging compartilhado por diversos produtos da DevOZ. O padrão descrito a seguir é, portanto, genérico; os exemplos referentes a caixas, postes, cabos ou clientes são ilustrações do OZmap.
+
+> [!NOTE]
+> **A auditoria é um canal local, independente do OpenTelemetry.**
+> A telemetria operacional é encaminhada ao SigNoz por meio do OpenTelemetry, consolidando informações de muitos clientes. Campos como `tenant`, `spanId`, `traceId`, `host` e atributos de recurso são gerados nesse fluxo e tratados diretamente no Fluent Bit; eles **não fazem parte da auditoria**. O canal de auditoria permanece exclusivamente na máquina do cliente (uma instância por cliente, com host único), no Victoria Logs local. Por tratar-se de um único tenant, o campo `tenant` é dispensável. O nível do registro (`severityText` e `severityNumber`) é mantido.
+
+O comportamento atual do `audit()` herda o estilo de `console.log(a, b, c)`, que agrupa os argumentos em `{0: …}` (originando o `body.0`) e não impõe limite de tamanho. Este documento substitui esse comportamento pela assinatura `audit(_msg, body)` e pela contingência descrita adiante.
+
+---
+
+## 4. O problema: registros de auditoria excessivamente grandes
+
+Considere o seguinte registro real (OZmap), aqui reduzido:
+
+```json
+{
+  "_id": { "$oid": "66f310126d9a8f0020291299" },
+  "request": "{\"query\":{\"$and\":[{\"_id\":{\"$in\":[ ...milhares de ObjectIds... ]}}]}}"
+}
+```
+
+O volume decorre de um único campo, que serializou a consulta com a totalidade do array `$in`. Trata-se, essencialmente, de um **problema de modelagem**: registrou-se a consulta de implementação (a lista expandida) em vez da intenção da operação. A intenção — "atualizar o status de N itens correspondentes ao filtro X" — é pequena. A correção adequada ocorre na origem; nesse cenário, a quebra sequer deveria ser acionada.
+
+---
+
+## 5. Limites do Victoria Logs e consumo de memória
+
+> [!WARNING]
+> **O limite existe para proteger a memória.**
+> Uma linha que exceda `-insert.maxLineSizeBytes` (valor padrão de 262144 bytes, equivalente a 256 KiB) é integralmente **descartada** durante o processamento, com registro de um aviso (WARN). A documentação indica que o objetivo é evitar a exaustão de memória. Registros próximos de 2 MB são processados de forma ineficiente. Manter cada linha pequena — auditando a intenção — é o que assegura uma ingestão estável.
+
+| Limite | Valor | Consequência ao exceder |
+| --- | --- | --- |
+| Tamanho da linha | 256 KiB (padrão) | Linha descartada (proteção de memória), com aviso |
+| Tamanho máximo do registro | cerca de 2 MB | Processamento ineficiente; elevar o parâmetro não resolve |
+| Campos por entrada | 1000 (padrão) | Entrada rejeitada |
+| Nome de campo | 128 bytes | Entrada ignorada |
+
+---
+
+## 6. Assinatura e estrutura do registro
+
+A assinatura passa a ser `audit(_msg: string, body: unknown)`: o primeiro parâmetro é a mensagem e o segundo é o corpo. Qualquer aridade diferente de dois constitui erro de programação e lança uma exceção. Com isso, elimina-se o estilo variádico (e o `body.0`) e define-se a mensagem de forma explícita.
+
+### 6.1. Envelope (logger) e corpo (chamador)
+
+| Camada | Responsável | Campos |
+| --- | --- | --- |
+| **Envelope** (reservado) | Logger | `_time`, `level`, `severityText`, `severityNumber`, `tag`, `audit_id`, `_msg` (primeiro parâmetro) e os campos de quebra (`chunked`, `chunk_seq`, `chunk_total`, `chunk_field`). O chamador não escreve nesta camada. |
+| **`body`** (área do chamador) | Chamador | O segundo parâmetro, tal como recebido. Se for um objeto, torna-se o conteúdo do corpo; se for um valor escalar, o corpo é o próprio valor. |
+
+A mensagem `_msg` é fornecida em separado e é sempre uma string, pois o Victoria Logs a utiliza como o texto exibido e como alvo padrão da busca textual — um corpo do tipo objeto não ofereceria essa string. Não integram o envelope: `traceId`, `spanId`, `host` e `tenant` (tratados no Fluent Bit, conforme [§3](#3-contexto)) e `pid`/`ppid` (conforme [§6.4](#64-os-campos-pid-e-ppid-não-integram-o-padrão)).
+
+### 6.2. Exemplo
+
+```jsonc
+// audit("alice login", { action: "login", user: "alice" }) produz:
+{
+  "_time": "2026-06-24T14:32:10.512Z",
+  "level": "AUDIT",
+  "severityText": "AUDIT",
+  "severityNumber": 12,
+  "tag": "MeuApp",
+  "audit_id": "01J8Z9K3F7AB...",
+  "_msg": "alice login",
+  "body": { "action": "login", "user": "alice" }
+}
+```
+
+### 6.3. O corpo como área isolada: proteção dos metadados
+
+Como o segundo parâmetro torna-se o `body` por inteiro, qualquer chave do chamador permanece contida no corpo e não afeta o envelope:
+
+```jsonc
+// audit("teste", { a: 1, LEVEL: "tentativa de sobrescrever o level" }) produz:
+{
+  "level": "AUDIT",
+  "tag": "MeuApp",
+  "audit_id": "01J8Z9...",
+  "_msg": "teste",
+  "body": { "a": 1, "LEVEL": "tentativa de sobrescrever o level" }
+}
+```
+
+Regra de implementação: o logger **não distribui o corpo na camada superior**; atribui `entry.body = body` de uma só vez. Dessa forma, a sobrescrita de metadados torna-se estruturalmente impossível.
+
+### 6.4. Os campos `pid` e `ppid` não integram o padrão
+
+Esses campos são pertinentes apenas ao OZmap, que opera em cluster de processos. **Não fazem parte do padrão de auditoria.** Caso um produto específico necessite deles, devem ser incluídos no `body`, nunca no envelope.
+
+---
+
+## 7. Princípio fundamental: auditar a intenção
+
+A forma correta de não exceder o limite é não produzir registros grandes:
+
+- Quando a seleção é feita por filtro, registre o **filtro e a contagem** — não os identificadores resolvidos.
+- Identificadores individuais devem ser registrados apenas quando relevantes (seleção manual ou exigência de rastreabilidade por item), em uma linha por item, de pequeno porte.
+- **Não se deve registrar a consulta bruta de forma literal** (o caso da [§4](#4-o-problema-registros-de-auditoria-excessivamente-grandes)).
+
+> [!TIP]
+> **Resultado:** o registro de 5 MB da [§4](#4-o-problema-registros-de-auditoria-excessivamente-grandes), remodelado para a intenção, reduz-se a poucos KB. A contingência da [§8](#8-contingência-a-quebra-de-registros-grandes) não chega a ser acionada. Este é o estado desejado.
+
+---
+
+## 8. Contingência: a quebra de registros grandes
+
+> [!WARNING]
+> **Trata-se de uma contingência, não de um recurso.**
+> A quebra existe por um único motivo: impedir que um registro grande seja perdido silenciosamente (descartado pelo logger ou pelo Victoria Logs). Destina-se a **casos extremos** e não deve ser tratada como caminho habitual de auditoria. Quando ocorre com frequência, há um defeito na origem, que deve ser corrigido conforme a [§7](#7-princípio-fundamental-auditar-a-intenção).
+
+> [!IMPORTANT]
+> **Toda quebra registra um ERROR com o `audit_id`.**
+> Cada quebra emite, obrigatoriamente, um registro de nível ERROR contendo o `audit_id`, que informa a ocorrência e solicita a correção na origem. Esse ERROR segue para o fluxo operacional (SigNoz) e deve ser tratado como alerta.
+
+```text
+ERROR AUDIT_OVERSIZE audit_id=01J8Z9K3F7AB... : o registro excedeu 256KB e precisou
+      ser quebrado em 34 partes. Esta é uma medida de contingência, não um recurso;
+      reduza o volume na origem (auditar a intenção). Consulte a §7.
+```
+
+### 8.1. A quebra preserva o primeiro nível do corpo
+
+Quando a quebra é inevitável, o corpo permanece utilizável, pois **quebram-se os valores, e não o envelope**. A linha de cabeçalho contém todas as chaves de primeiro nível; o valor que excedeu o limite é substituído por um marcador (`{ ref, type, bytes, sha1 }`, também consultável); e os dados volumosos são distribuídos em linhas de segmento, identificadas por `chunk_field` e associadas pelo mesmo `audit_id`.
+
+```jsonc
+// cabeçalho — esqueleto com todo o primeiro nível
+{
+  "_time": "...", "level": "AUDIT", "severityText": "AUDIT", "severityNumber": 12,
+  "tag": "reports", "audit_id": "01J8Z9...", "chunked": true, "chunk_total": 34,
+  "_msg": "report.generate",
+  "body": {
+    "action": "report.generate",   // inline — consultável
+    "user": "alice",               // inline — consultável
+    "result_csv": { "ref": "body.result_csv", "type": "string", "bytes": 5242880, "sha1": "ab12..." }
+  }
+}
+
+// segmento — array: fração em formato JSON (consultável por json_array_contains_any)
+{
+  "...envelope...": "...", "audit_id": "01J8Z9...", "chunk_seq": 3, "chunk_total": 34,
+  "chunk_field": "body.affected_ids",
+  "body": { "affected_ids": ["64f8...e09", "..."] }   // ~5000 itens por segmento
+}
+
+// segmento — escalar ou blob: fração em texto (reconstruída por concatenação, via chunk_field)
+{
+  "...envelope...": "...", "audit_id": "01J8Z9...", "chunk_seq": 7, "chunk_total": 34,
+  "chunk_field": "body.result_csv",
+  "chunk_part": "<fração de ~150KB>"
+}
+```
+
+Assim, mesmo no pior caso, o primeiro nível permanece consultável; apenas o conteúdo interno do campo volumoso requer reconstrução. A divisão é feita **por bytes**, e não por quantidade de itens. Caso o corpo possua um número de chaves elevado a ponto de exceder o limite de campos, a mesma técnica aplica-se às chaves: o conjunto é distribuído entre linhas que compartilham o `audit_id`.
+
+### 8.2. Alternativa para estudo futuro
+
+> [!NOTE]
+> **Pasta local para fidelidade integral — para estudo, não adotada.**
+> Cogitou-se gravar o conteúdo integral dos casos volumosos em uma pasta local (incluída no backup, já de longa duração, da máquina), mantendo no registro apenas o evento e uma referência. A proposta permanece como estudo, pelos seguintes motivos: introduz um ponto adicional de manutenção (arquivo, verificação de integridade, coleta de órfãos); diverge da filosofia do OZLogger, baseada apenas em stdout; e, com a auditoria por intenção ([§7](#7-princípio-fundamental-auditar-a-intenção)), os casos volumosos tornam-se raros. Caso a equipe retome a ideia, o local mais adequado seria o coletor (Fluent Bit) ou um componente auxiliar, preservando o logger. Registra-se para avaliação futura.
+
+---
+
+## 9. Função temporária para a ferramenta de importação
+
+> [!CAUTION]
+> **`auditChunked()` — `@deprecated`, temporária, a remover.**
+> A ferramenta de importação ainda produz registros grandes (listas de identificadores). Até que seja ajustada para auditar por intenção ([§7](#7-princípio-fundamental-auditar-a-intenção)), esta função permite que a importação opere sem perda silenciosa de dados, dividindo o corpo em linhas de até 256 KB. **Não constitui um recurso e não deve ser utilizada em código novo.** Cada chamada que necessite dividir o corpo emite o ERROR descrito na [§8](#8-contingência-a-quebra-de-registros-grandes). A função deve ser removida tão logo a importação passe a auditar por intenção.
+
+```ts
+/**
+ * @deprecated Função temporária (contingência) criada para a ferramenta de importação.
+ * Não é um recurso. Divide um corpo grande em linhas de auditoria de até 256KB para
+ * evitar a perda silenciosa no Victoria Logs, sempre emitindo um ERROR com o audit_id.
+ * Remover quando a importação passar a auditar por intenção (resumo e filtro).
+ */
+const SAFE_LINE_BYTES = 200 * 1024; // margem abaixo do limite de 256KB do Victoria Logs
+
+export function auditChunked(_msg: string, body: Record<string, unknown>): void {
+  const id = ulid();
+  const head = {
+    _time: now(), level: 'AUDIT', severityText: 'AUDIT', severityNumber: 12,
+    tag: logger.tag, audit_id: id, _msg,
+  };
+
+  if (byteLen(serialize({ ...head, body })) <= SAFE_LINE_BYTES) {
+    return logger.audit(_msg, body); // coube: caminho normal, sem divisão
+  }
+
+  // foi necessário dividir — condição anômala; registre um ERROR com o audit_id.
+  const { skeleton, heavy } = splitFirstLevel(body, SAFE_LINE_BYTES);
+  const total = countChunks(heavy, SAFE_LINE_BYTES);
+  logger.error(
+    `AUDIT_OVERSIZE audit_id=${id}: o corpo excedeu 256KB e foi dividido em ` +
+    `${total} partes. Contingência, não recurso; reduza na origem (§7). Remover no futuro.`
+  );
+
+  stdout({ ...head, body: skeleton, chunked: true, chunk_total: total });
+
+  for (const [field, value] of heavy) {
+    const parts = Array.isArray(value)
+      ? chunkArrayByBytes(value, SAFE_LINE_BYTES)
+      : chunkStringByBytes(stringify(value), SAFE_LINE_BYTES);
+
+    parts.forEach((part, i) => stdout({
+      _time: now(), level: 'AUDIT', tag: logger.tag, audit_id: id,
+      chunk_seq: i, chunk_total: parts.length, chunk_field: `body.${field}`,
+      ...(Array.isArray(value) ? { body: { [field]: part } } : { chunk_part: part }),
+    }));
+  }
+}
+```
+
+> O `audit()` padrão aplica a mesma contingência internamente (divisão acompanhada de ERROR), de modo a nunca perder dados silenciosamente. A diferença é que `auditChunked()` é explícita, nomeada e marcada como `@deprecated` — o que facilita sua localização e posterior remoção.
+
+---
+
+## 10. Modelagem para consulta
+
+Na ingestão, o Victoria Logs **achata o `body` em `body.*`** (objeto aninhado convertido em chaves separadas por ponto) e indexa cada campo — o que viabiliza consultas como `body.action:=login`. Recomenda-se:
+
+- Empregar **rótulos estáveis e de baixa cardinalidade** no corpo (por exemplo, `action`, `entity_type`, `result`).
+- Registrar **dados estruturados**, e não textos concatenados.
+- Definir como _stream fields_ apenas campos de baixa cardinalidade — `tag` e `level`. Os campos `audit_id` e `body.entity_id` **não** devem compor os _stream fields_, pois, como campos comuns, já são indexados nativamente. Configuração sugerida: `_stream_fields=tag,level`.
+
+---
+
+## 11. Consultas (LogsQL)
+
+> Nas consultas, os campos figuram em forma achatada (`body.x`), conforme indexados pelo Victoria Logs.
+
+**a) Autoria de uma ação nas últimas 24 horas**
+
+```text
+_time:24h level:=AUDIT body.action:=client.import | fields _time, _msg, body.affected_count
+```
+
+**b) Conteúdo completo de uma operação (cabeçalho e segmentos)**
+
+```text
+level:=AUDIT audit_id:=01J8Z9K3F7AB...
+```
+
+**c) Verificar se o item 12345 foi afetado por uma operação em lote**
+
+```text
+level:=AUDIT audit_id:=01J8Z9K3F7AB... json_array_contains_any(body.affected_ids, "12345")
+```
+
+**d) Ocorrências de quebra (que devem ser raras)**
+
+```text
+level:=ERROR _msg:~"AUDIT_OVERSIZE" | fields _time, _msg
+```
+
+---
+
+## 12. Matriz de decisão: conteúdo do corpo
+
+| Tipo de dado | No corpo | Se exceder (contingência) | Não permitido |
+| --- | --- | --- | --- |
+| Identidade, ação e contagem | ✓ inline | — | — |
+| Alteração de campo escalar | ✓ anterior/novo | — | — |
+| Seleção por filtro | ✓ critério e contagem | — | identificadores resolvidos |
+| Campo de tipo array de grande porte | cabeçalho e marcador | quebra §8 (array JSON) e ERROR | array completo em uma linha |
+| Campo escalar ou blob de grande porte | marcador (`ref`/`bytes`/`sha1`) | quebra §8 (frações de texto) e ERROR | valor bruto inline |
+| Consulta bruta (`$in` expandido) | — | — | de forma literal (a [§4](#4-o-problema-registros-de-auditoria-excessivamente-grandes)) |
+| `pid` e `ppid` | apenas se o produto exigir | — | no envelope padrão |
+| `tenant`, `traceId`, `spanId`, host | — | Fluent Bit → SigNoz | na auditoria |
+| Senha, token, segredo, chave | — | — | **redigir** (`filter()`) |
+| E-mail, CPF e dados pessoais | ✓ visíveis (auditoria local) | — | — |
+
+---
+
+## 13. Observabilidade e dados sensíveis
+
+- **Ocorrência de quebra:** o ERROR `AUDIT_OVERSIZE` ([§8](#8-contingência-a-quebra-de-registros-grandes)) é o principal indicador. Cada ocorrência corresponde a uma auditoria a ser corrigida na origem e deve ser tratada como alerta.
+- **Descarte no Victoria Logs:** recomenda-se monitorar `vl_rows_dropped_total` e o aviso de "linha longa". Com a contingência em funcionamento, esses valores permanecem em zero.
+- **Integridade dos segmentos:** na reconstrução, deve-se verificar se foram recebidos os `chunk_total` segmentos esperados.
+
+> [!IMPORTANT]
+> **Dados sensíveis: a natureza local da auditoria define a regra.**
+> Como a auditoria permanece exclusivamente na máquina do cliente (um único tenant, com dados do próprio cliente), não há risco de vazamento entre clientes. Por esse motivo, **redigem-se apenas senhas** — e credenciais equivalentes, como tokens, chaves de API e segredos, dado que uma credencial exposta é perigosa em qualquer contexto. **E-mail, CPF e demais dados pessoais permanecem visíveis**, por serem dados do próprio cliente, em seu ambiente. Recomenda-se utilizar `filter()` para remover senhas e segredos na emissão; dados pessoais não devem ser mascarados nem removidos.
+
+---
+
+## 14. Consequências
+
+### Benefícios
+
+- A assinatura `audit(_msg, body)` é previsível, elimina o `body.0` e resolve a definição da mensagem.
+- Não há perda silenciosa de dados; quando a contingência é acionada, ela sinaliza a necessidade de correção.
+- Os registros são pequenos por padrão (auditoria por intenção); a quebra é uma exceção rara.
+- Mesmo em situação de excesso, o primeiro nível do corpo permanece consultável.
+- O isolamento do corpo elimina a sobrescrita de metadados.
+
+### Custos e migração
+
+- As chamadas no estilo antigo (variádico) e os leitores de `body.0` devem migrar para `audit(_msg, body)` e `body.*`.
+- A função `auditChunked()` constitui dívida técnica explícita: existe para a importação e deve ser removida ([§9](#9-função-temporária-para-a-ferramenta-de-importação)).
+- O conteúdo interno de um campo dividido só é consultável após a reconstrução.
+- Aridade incorreta passa a lançar erro, evidenciando-se em ambiente de desenvolvimento e de testes.
+
+---
+
+## 15. Referências
+
+1. **OZLogger** — `github.com/ozmap/logger`. Módulo de logging compartilhado; arquitetura baseada em stdout; funções `mask()` e `filter()`.
+2. **Victoria Logs** — *Key Concepts* e *FAQ* (achatamento de JSON; _stream fields_; limite de 128 bytes por nome de campo; número máximo de campos; tamanho de registro de cerca de 2 MB). <https://docs.victoriametrics.com/victorialogs/>
+3. **Victoria Logs** — *Metrics* e parâmetros de configuração (`maxLineSizeBytes` de 256 KB; descarte de linhas grandes para preservar memória).
+4. **Victoria Logs** — *LogsQL* (filtro `json_array_contains_any`; recomendação de campos separados em vez de JSON no `_msg`).
+5. Bibliografia de apoio: *Designing Data-Intensive Applications* (M. Kleppmann); *Clean Architecture* (R. C. Martin); *Implementing Domain-Driven Design* (V. Vernon); *Learning Domain-Driven Design* (V. Khononov); *Enterprise Integration Patterns* (G. Hohpe e B. Woolf); *OWASP Logging Cheat Sheet*; *NIST SP 800-92*; *ISO/IEC 27001* e *27002*.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -26,6 +26,14 @@ Cada task segue a estrutura:
 | [045](task-045-log-rotation/) | [#45](https://github.com/ozmap/ozlogger/issues/45) | Log Rotation | 🟡 Média | Bloqueado (#44) |
 | [046](task-046-internal-metrics/) | [#46](https://github.com/ozmap/ozlogger/issues/46) | Métricas Internas | 🟡 Média | Não Iniciado |
 | [047](task-047-jsdoc-docs/) | [#47](https://github.com/ozmap/ozlogger/issues/47) | Docs JSDoc | 🟢 Baixa | Não Iniciado |
+| [088](task-088-audit-chunk-util/) | [#88](https://github.com/ozmap/logger/issues/88) | Util de Quebra de Logs (AuditChunk) | 🔴 Crítico | Não Iniciado |
+| [089](task-089-audit-signature/) | [#89](https://github.com/ozmap/logger/issues/89) | Assinatura `audit(_msg, body)` e Envelope | 🔴 Crítico | Não Iniciado |
+| [090](task-090-audit-oversize-contingency/) | [#90](https://github.com/ozmap/logger/issues/90) | Contingência de Quebra + ERROR AUDIT_OVERSIZE | 🟠 Alta | Bloqueado (#88, #89) |
+| [091](task-091-audit-rfc-docs/) | [#91](https://github.com/ozmap/logger/issues/91) | Docs do Padrão de Auditoria (RFC-001) | 🟢 Baixa | Bloqueado (#89) |
+
+> **RFC [OZLOGGER-AUDIT-001](../rfc/RFC-OZLOGGER-AUDIT-001.md):** as tasks #88–#91 implementam o
+> padrão de auditoria (assinatura `audit(_msg, body)`, fim do `body.0`, contingência de quebra).
+> O conjunto mínimo de **código** é #88 → #89 → #90; a #91 é doc-only e opcional.
 
 ## Prioridades
 
@@ -45,6 +53,13 @@ flowchart TD
     T034 --> T037["#37\nProcess Hang"]
     T037 --> T038["#38\nHTTP Port"]
     T038 --> T039["#39\nTimer ID"]
+
+    subgraph RFC["RFC-OZLOGGER-AUDIT-001"]
+        T088["#88\nAuditChunk util"] --> T090["#90\nContingência + ERROR"]
+        T089["#89\naudit(_msg, body)"] --> T090
+        T088 -.audit_id/envelope.-> T089
+        T089 --> T091["#91\nDocs (opcional)"]
+    end
 ```
 
 ## Como Criar Nova Task

--- a/docs/tasks/task-088-audit-chunk-util/Context.md
+++ b/docs/tasks/task-088-audit-chunk-util/Context.md
@@ -1,0 +1,105 @@
+# Contexto Técnico - Task #88
+
+## Por que um util puro e separado
+
+A RFC (§9) traz a `auditChunked()` chamando `splitFirstLevel`, `chunkArrayByBytes`,
+`chunkStringByBytes`, `countChunks`, `byteLen`. O requisito do produto é que
+**a quebra seja feita igual em todo lugar** — `audit()` interno, a `auditChunked()`
+da ferramenta de importação e quaisquer outros projetos DevOZ. A única forma de
+garantir isso é uma função pura, sem efeito colateral, exportada pelo pacote.
+
+> Princípio: **a quebra calcula; o consumidor emite.** O util retorna estruturas
+> de dados; quem escreve em `stdout` é o `Logger` (Task #90). Isso mantém o util
+> testável isoladamente e idêntico entre projetos.
+
+## Arquivo novo
+
+`lib/util/AuditChunk.ts` — não existe ainda (confirmado: não há código de
+chunk/split/ulid em `lib/`). Deve usar apenas `node:crypto` (já usado em
+`lib/util/Objects.ts` para sha1) — **nenhuma dependência nova**.
+
+## API proposta (superfície exportada)
+
+```ts
+export const SAFE_LINE_BYTES = 200 * 1024; // margem abaixo do limite de 256KB do Victoria Logs
+
+/** Tamanho em bytes UTF-8 do valor já serializado. */
+export function byteLen(value: unknown): number;
+
+/** Gera um audit_id ULID (26 chars, Crockford base32), monotônico, zero-dep. */
+export function auditId(): string;
+
+/** Separa o primeiro nível: o que cabe vira skeleton inline; o que excede vira marcador. */
+export function splitFirstLevel(
+  body: Record<string, unknown>,
+  limit: number
+): { skeleton: Record<string, unknown>; heavy: Array<[string, unknown]> };
+
+export function chunkArrayByBytes(arr: unknown[], limit: number): unknown[][];
+export function chunkStringByBytes(str: string, limit: number): string[];
+export function countChunks(heavy: Array<[string, unknown]>, limit: number): number;
+
+/** Marcador para um valor pesado removido do skeleton. */
+export function heavyMarker(field: string, value: unknown):
+  { ref: string; type: string; bytes: number; sha1: string };
+
+/**
+ * Função de topo: dado um corpo, devolve a linha de cabeçalho e as linhas de
+ * segmento como DADOS PUROS (não emite nada). Quem consome adiciona o envelope
+ * (audit_id, _time, level...) e escreve.
+ */
+export function splitAuditBody(
+  body: unknown,
+  opts: { limit?: number; auditId?: string }
+): {
+  header: { body: Record<string, unknown>; chunked: true; chunk_total: number };
+  segments: Array<
+    | { chunk_seq: number; chunk_total: number; chunk_field: string; body: Record<string, unknown> }   // array
+    | { chunk_seq: number; chunk_total: number; chunk_field: string; chunk_part: string }               // escalar/blob
+  >;
+};
+```
+
+> Estável para outros projetos: `splitAuditBody`, `auditId`, `SAFE_LINE_BYTES`,
+> `heavyMarker`. Os chunkers de baixo nível são exportados para composição, mas
+> `splitAuditBody` é o ponto de entrada recomendado.
+
+## Marcador de valor pesado (§8.1)
+
+```jsonc
+"result_csv": { "ref": "body.result_csv", "type": "string", "bytes": 5242880, "sha1": "ab12..." }
+```
+
+- `ref`  = `body.<campo>`
+- `type` = tipo do valor (`'string'`, `'array'`, ...)
+- `bytes`= `Buffer.byteLength(serialize(valor), 'utf8')`
+- `sha1` = `createHash('sha1').update(serialize(valor)).digest('hex')`
+
+## Segmentos (§8.1) — resolução da ambiguidade `chunk_total`/`chunk_seq`
+
+A RFC tem uma inconsistência: §8.1 (prosa/exemplos) mostra `chunk_total: 34` no
+**cabeçalho e nos segmentos** com `chunk_seq` como **sequência global**; já o
+pseudocódigo da §9 usa `parts.length` por campo. **Resolução adotada (alinhada à
+§8.1, que é a especificação):**
+
+- `chunk_total` = **número total de linhas de segmento** (global), presente no cabeçalho e em cada segmento.
+- `chunk_seq`   = índice **global** 0-based da linha de segmento.
+- `chunk_field` = qual campo do corpo aquele segmento reconstrói.
+- Reconstrução: coletar segmentos pelo `audit_id`, conferir que chegaram `chunk_total`,
+  agrupar por `chunk_field`, ordenar por `chunk_seq`, concatenar (texto) ou unir (array).
+
+> ⚠️ Decisão a confirmar — ver `Summary.md`. O default acima remove a ambiguidade.
+
+## Estouro por número de campos (§8.1 / §5)
+
+O Victoria Logs limita ~1000 campos por entrada e 128 bytes por nome de campo.
+Quando o corpo tem chaves demais, a **mesma técnica** se aplica às chaves: o
+conjunto é distribuído entre linhas de cabeçalho/segmento que compartilham o
+`audit_id`. Default sugerido: dividir quando o nº de chaves de primeiro nível
+ultrapassar um limite configurável (ex.: 900, com margem sob 1000).
+
+## Referências no código
+
+- `lib/util/Objects.ts` — uso de `createHash('sha1')` (padrão a seguir, sem dep nova).
+- `lib/Logger.ts` linhas ~296-301 — branch de oversize que **descarta** hoje (será substituído pela Task #90 usando este util).
+- RFC §9 — pseudocódigo de `auditChunked()` (fonte das funções).

--- a/docs/tasks/task-088-audit-chunk-util/Progress.md
+++ b/docs/tasks/task-088-audit-chunk-util/Progress.md
@@ -1,0 +1,24 @@
+# Progresso - Task #88: Util de Quebra (AuditChunk)
+
+## Status Atual
+
+🔴 **Não Iniciado**
+
+## Checklist
+
+- [ ] Criar `lib/util/AuditChunk.ts` (módulo puro, sem `Logger`, sem `stdout`)
+- [ ] Implementar `byteLen`, `auditId` (ULID inline zero-dep), `heavyMarker`
+- [ ] Implementar `splitFirstLevel` (skeleton inline + marcadores)
+- [ ] Implementar `chunkArrayByBytes` e `chunkStringByBytes` (divisão por bytes)
+- [ ] Implementar `countChunks` e a função de topo `splitAuditBody`
+- [ ] Implementar estouro por nº de campos (key-set splitting)
+- [ ] Exportar superfície pública em `lib/index.ts` (ESM + CJS `Object.assign`)
+- [ ] Criar `tests/auditChunk.test.ts` (importa o util **sem** o `Logger`)
+- [ ] Provar ausência de efeito colateral (espião em `process.stdout.write`/`console`)
+- [ ] Provar determinismo byte a byte (entrada fixa → saída fixa)
+
+## Histórico
+
+| Data | Ação | Resultado |
+|------|------|-----------|
+| 2026-06-25 | Task criada a partir da RFC-OZLOGGER-AUDIT-001 | Aguardando implementação |

--- a/docs/tasks/task-088-audit-chunk-util/Summary.md
+++ b/docs/tasks/task-088-audit-chunk-util/Summary.md
@@ -1,0 +1,41 @@
+# Resumo Executivo - Task #88
+
+## Visão Geral
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | task-088 |
+| **GitHub** | [#88](https://github.com/ozmap/logger/issues/88) |
+| **Título** | Util Reutilizável de Quebra de Logs de Auditoria (`AuditChunk`) |
+| **RFC** | [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §5, §8, §9 |
+| **Prioridade** | 🔴 Crítico (fundação) |
+| **Depende de** | — |
+| **Bloqueia** | #90 (contingência) e fornece contrato a #89 |
+
+## Impacto
+
+Entrega o coração da RFC: a lógica de quebra de registros grandes como **função
+pura e reutilizável**. Garante o requisito do produto — "todo lugar que quebrar
+o log o faz igual" — porque há **uma única implementação**, exportada pelo
+pacote e idêntica para `audit()`, `auditChunked()` e projetos externos.
+
+## Decisões a confirmar (defaults já adotados nos docs)
+
+1. **Gerador de `audit_id`:** ULID inline **zero-dep** (usa `node:crypto`, já
+   presente). *Alternativas:* adicionar dependência `ulid` (fere a filosofia de
+   1 dependência do projeto) ou usar `crypto.randomUUID()` (muda o formato dos
+   exemplos LogsQL da RFC). **Recomendado: ULID inline.**
+2. **`chunk_total`/`chunk_seq`:** adotada a semântica **global** da §8.1
+   (`chunk_total` = total de segmentos; `chunk_seq` = índice global), resolvendo
+   a divergência com o pseudocódigo per-campo da §9.
+3. **Limite de estouro por nº de campos:** configurável, default ~900 (margem sob
+   o teto de 1000 do Victoria Logs); guarda de nome de campo (128 bytes) é
+   opcional nesta fase.
+4. **Pureza/arquitetura:** o util **retorna dados e não emite** — a emissão é da
+   Task #90. Decisão central para a reutilização entre projetos.
+
+## Risco
+
+Baixo isoladamente (sem efeito colateral, testável em unidade). O principal risco
+é de **contrato**: o formato do `audit_id` e do envelope precisa ser combinado com
+a Task #89 antes de a Task #90 integrar, para evitar retrabalho.

--- a/docs/tasks/task-088-audit-chunk-util/Task.md
+++ b/docs/tasks/task-088-audit-chunk-util/Task.md
@@ -1,0 +1,84 @@
+# Task #88: Util Reutilizável de Quebra de Logs de Auditoria (`AuditChunk`)
+
+> RFC: [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §5, §8 (8.1), §9
+
+## Objetivo
+
+Criar um **módulo utilitário puro e reutilizável** que implementa a lógica de
+quebra de registros de auditoria grandes em segmentos de tamanho seguro para o
+Victoria Logs. Esta é a peça central da RFC: a quebra precisa ser feita **uma
+única vez, num único lugar**, e exportada de forma que **qualquer outro projeto
+da DevOZ a use exatamente da mesma maneira** (mesma entrada → mesma saída,
+byte a byte).
+
+## Descrição
+
+Hoje a quebra não existe: o `audit()` simplesmente **descarta** corpos acima de
+256 KB (`lib/Logger.ts`, branch de oversize). A RFC (§8) exige uma contingência
+que nunca perca dados, quebrando os **valores** (não o envelope) em linhas de
+até ~200 KB.
+
+Esta task entrega **apenas a matemática da quebra**, como funções puras, sem
+qualquer efeito colateral (não escreve em `stdout`/`console`, não importa o
+`Logger`, não formata nem coloriza). O módulo recebe um corpo e devolve **dados
+planos** (linha de cabeçalho + linhas de segmento) que o consumidor emite. Assim
+o `Logger` (Task #90) e qualquer projeto externo compartilham a mesma lógica,
+sem fork.
+
+Arquivo novo proposto: `lib/util/AuditChunk.ts`, exportado por `lib/index.ts`.
+
+## Escopo
+
+### Inclui
+
+- Função de topo `splitAuditBody(body, opts)` → `{ header, segments[] }` (dados planos).
+- Gerador de `audit_id` (ULID inline, **zero dependências**) reutilizado pelo envelope (Task #89) e pela quebra (Task #90).
+- Helpers de baixo nível, também exportados para composição por outros projetos:
+  - `byteLen(value)` — tamanho em bytes UTF-8 via `Buffer.byteLength`.
+  - `splitFirstLevel(body, limit)` → `{ skeleton, heavy[] }`.
+  - `chunkArrayByBytes(arr, limit)` e `chunkStringByBytes(str, limit)`.
+  - `countChunks(heavy, limit)`.
+  - Construtor de marcador `{ ref, type, bytes, sha1 }` (sha1 via `node:crypto`).
+- Constante `SAFE_LINE_BYTES = 200 * 1024`.
+- Tratamento de **estouro por número de campos** (§8.1, §5): quando o corpo tem
+  mais chaves de primeiro nível do que o limite, distribuir o conjunto de chaves
+  entre linhas correlacionadas pelo mesmo `audit_id`.
+
+### Não inclui
+
+- Emissão para `stdout`/cliente de log (fica na Task #90).
+- Mudança da assinatura do `audit()` (Task #89).
+- Documentação de consulta/modelagem (Task #91).
+
+## Critérios de Aceitação
+
+- [ ] `lib/util/AuditChunk.ts` **não importa** `Logger` e **não produz nenhuma
+      saída** em `process.stdout`/`console` ao rodar (provado por espião nos testes).
+- [ ] `splitAuditBody` retorna `{ header, segments[] }` como **dados puros** (não emite nada).
+- [ ] `splitFirstLevel(body, SAFE_LINE_BYTES)` preserva **todas** as chaves de
+      primeiro nível no `skeleton`; chaves que cabem ficam inline; cada chave que
+      excede é substituída por **exatamente** `{ ref: 'body.<campo>', type, bytes, sha1 }`,
+      com `bytes = Buffer.byteLength(serializado)` e `sha1 = sha1(serializado)`.
+- [ ] A divisão é **por bytes** (`Buffer.byteLength`), nunca por contagem de itens:
+      cada segmento serializado tem tamanho `<= SAFE_LINE_BYTES` mesmo com itens de tamanhos variados.
+- [ ] Campo **array** grande → segmentos com `body: { [campo]: <fração> }` (fragmento JSON, consultável), **sem** `chunk_part`.
+- [ ] Campo **escalar/blob** grande → segmentos com `chunk_part: '<fração de texto>'`, **sem** `body[campo]`;
+      concatenar `chunk_part` na ordem de `chunk_seq` reproduz o valor original serializado.
+- [ ] Estouro por nº de campos: corpo com mais chaves que o limite gera múltiplas
+      linhas correlacionadas (nenhuma linha excede o limite de campos).
+- [ ] `auditId()` gera identificador de formato estável (ULID 26 chars Crockford base32), **sem novas dependências de runtime**.
+- [ ] `SAFE_LINE_BYTES === 200 * 1024` e é distinto do gatilho do `Logger`.
+- [ ] Cobertura unitária em arquivo isolado `tests/auditChunk.test.ts` (importando o util **sem** o `Logger`).
+
+## Prioridade
+
+🔴 Crítico (fundação — bloqueia a Task #90)
+
+## Dependências
+
+- Nenhuma a montante. **Bloqueia** a Task #90 e fornece `auditId()`/contrato de envelope à Task #89.
+
+## Estimativa
+
+- **Esforço:** 2 dias
+- **Complexidade:** Média-Alta

--- a/docs/tasks/task-089-audit-signature/Context.md
+++ b/docs/tasks/task-089-audit-signature/Context.md
@@ -1,0 +1,90 @@
+# Contexto Técnico - Task #89
+
+## Estado atual (o que muda)
+
+### `lib/Logger.ts` — `buildAudit()` (linhas ~267-318)
+
+- Guarda de aridade hoje: `if (args.length !== 1) throw ...` → **inverter para exigir 2**
+  (`_msg = args[0]`, `body = args[1]`); manter o `throw` **antes** do check de `enabled`
+  (erro de programação aparece mesmo com nível desabilitado).
+- Validação de `_msg`: a RFC diz que é sempre `string`. Default recomendado: **lançar
+  `TypeError`** se `args[0]` não for string (coerência com a filosofia de "erro de
+  programação"). *Alternativa:* `String(_msg)`. Ver decisão no `Summary.md`.
+- Gerar `audit_id` via `auditId()` (util da Task #88).
+- A chamada `this.logger('AUDIT', data)` precisa passar `_msg`/`audit_id`/`body`
+  separadamente para que o envelope seja montado **sem** o proxy `body.0`.
+- Preservar o branch de **não serializável** (try/catch atual, linhas ~283-291).
+- O branch de **oversize** (linhas ~296-301) é tratado na Task #90 — nesta task,
+  manter o comportamento atual ou apenas deixar o gancho pronto (combinar com #90).
+
+### `lib/format/json.ts` — `toStructuredJsonLog` / `json()`
+
+Fonte do `body.0`:
+
+- linha ~37 `data` (depreciado) e ~41 `body: data` (alias) + ~56-60 `push()` fazendo `data[i++] = value`.
+
+Para auditoria, o envelope deve:
+
+1. atribuir `body = body` **inteiro** (sem `data[i++]`, sem alias `data`);
+2. emitir `_time` (ISO) **sempre** (não o `timestamp` condicional);
+3. **não** espalhar `...this.getContext()` (que injeta `pid`/`ppid`/`traceId`/`spanId`);
+4. incluir `audit_id` e `_msg` vindos do `buildAudit`;
+5. manter `severityText: 'AUDIT'` e `severityNumber: 12`.
+
+Os níveis não-audit podem manter o comportamento atual → provável **branch
+específico de AUDIT** (ou wrapper de auditoria dedicado).
+
+### `lib/util/interface/LoggerMethods.ts` (linhas 9-20)
+
+`AuditMethod` muda de `((data: unknown) => void)` para
+`((_msg: string, body: unknown) => void) & { timeEnd(id: string): Logger }`.
+Atualizar o comentário de contrato (descreve "exatamente UM argumento").
+
+### `lib/util/Helpers.ts` — `datetime()` (linhas 190-203)
+
+Emite `timestamp` e só com `OZLOGGER_DATETIME=true`. A auditoria precisa de `_time`
+**sempre**. Recomendado: o construtor do envelope de auditoria define `_time`
+diretamente (ISO UTC), em vez de reusar esse helper gated. `getProcessInformation()`
+permanece, mas **não** alimenta o envelope de auditoria.
+
+## Envelope-alvo (linha única) — §6.2
+
+```jsonc
+// audit("alice login", { action: "login", user: "alice" })
+{
+  "_time": "2026-06-24T14:32:10.512Z",
+  "level": "AUDIT",            // depreciado, mantido por compat (§6.1 lista 'level')
+  "severityText": "AUDIT",
+  "severityNumber": 12,
+  "tag": "MeuApp",
+  "audit_id": "01J8Z9K3F7AB...",
+  "_msg": "alice login",
+  "body": { "action": "login", "user": "alice" }
+}
+```
+
+> Campo depreciado `data` (origem do `body.0`) **é removido** do envelope de
+> auditoria. `level` (= `'AUDIT'`) é mantido por compatibilidade (consta na §6.1).
+
+## Isolamento de metadados (§6.3)
+
+Atribuir `body` inteiro é o que garante que `audit('t', { LEVEL: 'x' })` mantenha
+`LEVEL` aninhado em `body` sem tocar no envelope. **Regra:** nunca espalhar o
+corpo na camada superior.
+
+## Testes a reescrever — `tests/audit.test.ts`
+
+- linhas 31-34, 52-54: trocam `body['0']` por `body` (objeto direto / escalar direto);
+- linhas 26, 47-49: chamadas de 1 arg → `audit(_msg, body)`;
+- linhas 59-83: aridade — **2 passa**, 0/1/3 lançam;
+- novas asserções: `_time` (ISO, independe de `OZLOGGER_DATETIME`), `_msg`, `audit_id`,
+  ausência de `pid`/`ppid`/`traceId`/`spanId`, corpo inteiro, chaves do chamador aninhadas;
+- teste negativo: `email`/`cpf` **não** mascarados.
+
+> O teste de oversize (linhas 88-98) muda na Task #90 (passa de "descarta" para "quebra + ERROR").
+> Nesta task, ajustar apenas o necessário para não quebrar a suíte, deixando claro o handoff.
+
+## Migração (consumidores)
+
+Chamadas no estilo antigo (variádico / leitura de `body.0`) migram para
+`audit(_msg, body)` e `body.*`. Documentado na Task #91.

--- a/docs/tasks/task-089-audit-signature/Progress.md
+++ b/docs/tasks/task-089-audit-signature/Progress.md
@@ -1,0 +1,26 @@
+# Progresso - Task #89: Assinatura audit(_msg, body)
+
+## Status Atual
+
+🔴 **Não Iniciado**
+
+## Checklist
+
+- [ ] Inverter a guarda de aridade em `buildAudit` (exigir 2 args; lançar caso contrário)
+- [ ] Extrair `_msg` (string) e `body`; validar tipo de `_msg` (decisão: throw)
+- [ ] Gerar `audit_id` via `auditId()` (Task #88)
+- [ ] Passar `_msg`/`audit_id`/`body` ao caminho de emissão sem o proxy `body.0`
+- [ ] `json.ts`: branch AUDIT — `body` inteiro, `_time` sempre, sem `getContext()`
+- [ ] Remover `data` (depreciado) do envelope de auditoria; manter `level`
+- [ ] Preservar branch de corpo não serializável (não derrubar processo)
+- [ ] Definir saída mínima do `text.ts` para auditoria (não lançar)
+- [ ] Atualizar `AuditMethod` em `LoggerMethods.ts` + comentário
+- [ ] Atualizar JSDoc de `audit` público e `buildAudit`
+- [ ] Reescrever `tests/audit.test.ts` (body.0→body, aridade, _msg, audit_id, _time, exclusões)
+- [ ] Teste negativo: email/cpf não mascarados
+
+## Histórico
+
+| Data | Ação | Resultado |
+|------|------|-----------|
+| 2026-06-25 | Task criada a partir da RFC-OZLOGGER-AUDIT-001 | Aguardando implementação |

--- a/docs/tasks/task-089-audit-signature/Summary.md
+++ b/docs/tasks/task-089-audit-signature/Summary.md
@@ -1,0 +1,41 @@
+# Resumo Executivo - Task #89
+
+## Visão Geral
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | task-089 |
+| **GitHub** | [#89](https://github.com/ozmap/logger/issues/89) |
+| **Título** | Assinatura `audit(_msg, body)` e Isolamento do Envelope |
+| **RFC** | [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §1, §2, §6, §10–§11, §14 |
+| **Prioridade** | 🔴 Crítico (API breaking) |
+| **Depende de** | #88 (leve: `auditId()` + contrato de envelope) |
+| **Bloqueia** | #90, #91 |
+
+## Impacto
+
+Encerra o estilo variádico e o campo `body.0`, define a mensagem de forma
+explícita (`_msg`) e isola o corpo do envelope (sobrescrita de metadados torna-se
+impossível). Habilita as consultas LogsQL da RFC (§11) — `_msg`, `audit_id` e
+`body.*` passam a existir de forma plana e indexável. **Mudança quebra-contrato:**
+chamadas antigas e leitores de `body.0` precisam migrar.
+
+## Decisões a confirmar (defaults adotados nos docs)
+
+1. **`_time` sempre presente e nomeado `_time`** (não `timestamp`) no envelope de
+   auditoria, independentemente de `OZLOGGER_DATETIME`. Confirmar se demais níveis
+   mantêm o `timestamp` gated (i.e. `_time` é exclusivo de auditoria) ou se o logger
+   migra por inteiro. **Recomendado: `_time` exclusivo de auditoria.**
+2. **`_msg` não-string com aridade 2:** **lançar `TypeError`** (erro de programação).
+   *Alternativa:* `String(_msg)`.
+3. **Campo depreciado `data`:** **removido** do envelope de auditoria (era a origem
+   do `body.0`). `level` (= `'AUDIT'`) mantido por compat (consta na §6.1).
+4. **Arquitetura de emissão:** branch específico de AUDIT em `json.ts` (corpo inteiro,
+   `_time`, sem `getContext()`), combinado com o `buildAudit`. Deve bater **byte a byte**
+   com o envelope das linhas de quebra da Task #90.
+
+## Risco
+
+Médio: é uma mudança quebra-contrato com impacto em consumidores e em toda a
+suíte `tests/audit.test.ts`. Mitigação: caminho de linha única é pequeno e
+independente; a contingência (mais arriscada) fica isolada na Task #90.

--- a/docs/tasks/task-089-audit-signature/Task.md
+++ b/docs/tasks/task-089-audit-signature/Task.md
@@ -1,0 +1,81 @@
+# Task #89: Assinatura `audit(_msg, body)` e Isolamento do Envelope
+
+> RFC: [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §1, §2, §6 (6.1–6.4), §10–§11, §14
+
+## Objetivo
+
+Substituir o contrato atual do `audit()` pela assinatura fixa
+`audit(_msg: string, body: unknown)`, eliminar o campo `body.0` e produzir um
+envelope de auditoria limpo, com `_msg` e `audit_id` explícitos e os metadados
+estruturalmente protegidos contra sobrescrita.
+
+## Descrição
+
+Hoje (`lib/Logger.ts` + `lib/format/json.ts`):
+
+- `audit()` aceita **exatamente 1 argumento** e o wrapper JSON o empacota em
+  `data[i++]`, gerando `body: { "0": <valor> }` — o **problema do `body.0`** que a
+  RFC encerra.
+- Não há `_msg` explícito (a mensagem não é definível).
+- Não há `audit_id`.
+- O envelope ainda vaza `pid`/`ppid`/`traceId`/`spanId` via `getContext()`.
+
+A RFC (§6) define dois parâmetros: o primeiro é a **mensagem** (sempre `string`,
+usada pelo Victoria Logs como texto exibido e alvo de busca); o segundo é o
+**corpo**, atribuído **inteiro** a `entry.body` (`entry.body = body`), nunca
+distribuído na camada superior — o que torna a sobrescrita de metadados
+impossível por construção (§6.3).
+
+Esta task entrega o **caminho de linha única** (corpo que cabe no limite). A
+contingência de quebra fica na Task #90.
+
+## Escopo
+
+### Inclui
+
+- `audit()` exige **aridade exatamente 2**; qualquer outra aridade lança erro
+  (mesmo com o nível desabilitado), como erro de programação (§6, §14).
+- `_msg` (1º arg, `string`) e `audit_id` (do util da Task #88) no envelope.
+- `body` atribuído inteiro (objeto vira `body.*`; escalar vira o próprio valor) — **fim do `body.0`**.
+- Envelope de auditoria **sem** `pid`, `ppid`, `traceId`, `spanId`, `host`, `tenant` (§3, §6.4).
+- `_time` (ISO-8601 UTC) **sempre presente** no envelope de auditoria.
+- Mantém `severityText: 'AUDIT'` e `severityNumber: 12`.
+- Preserva o comportamento atual de corpo **não serializável** (reporta via erro, não derruba o processo).
+- Atualiza o tipo `AuditMethod` e os JSDoc.
+- Atualiza `tests/audit.test.ts` para o novo contrato.
+
+### Não inclui
+
+- Quebra de corpos grandes / `auditChunked()` (Task #90).
+- Documentação de consulta/modelagem/dados sensíveis (Task #91).
+
+## Critérios de Aceitação
+
+- [ ] `audit()`, `audit('m')`, `audit('m', b, c)` **lançam erro** (inclusive com nível desabilitado); `audit('m', body)` **não** lança.
+- [ ] `JSON.parse(out)._msg === ` 1º argumento; `out.audit_id` é string não vazia (formato conforme decisão da #88).
+- [ ] **`body.0` eliminado:** `audit('m', { action: 'login' })` → `out.body` deep-equal `{ action: 'login' }` e `out.body['0'] === undefined`. Escalar: `audit('m', 42)` → `out.body === 42`.
+- [ ] **Isolamento:** `audit('t', { a: 1, LEVEL: 'x', level: 'x', tag: 'x', audit_id: 'x' })` →
+      `out.level === 'AUDIT'`, `out.tag === <tag do logger>`, `out.audit_id === <id gerado>` (não `'x'`),
+      e as chaves do chamador permanecem aninhadas em `out.body`.
+- [ ] Envelope de auditoria **não contém** `pid`, `ppid`, `traceId`, `spanId`, `host`, `tenant`, mesmo com span OTel ativo.
+- [ ] `out._time` é ISO-8601 UTC válido em **todo** registro de auditoria, independentemente de `OZLOGGER_DATETIME`.
+- [ ] `severityText === 'AUDIT'` e `severityNumber === 12`.
+- [ ] Corpo não serializável não derruba o processo e é reportado via erro (comportamento atual preservado).
+- [ ] Saída em `OZLOGGER_OUTPUT=text` para `audit(_msg, body)` não lança (formato mínimo: `_msg` + corpo serializado).
+- [ ] `AuditMethod` em `LoggerMethods.ts` atualizado para `(_msg: string, body: unknown) => void` + `timeEnd`.
+- [ ] **Teste negativo:** `email`/`cpf` no corpo **não** são mascarados/filtrados pelo logger (§13 — não introduzir redaction no caminho de auditoria).
+- [ ] JSDoc do `audit` público e de `buildAudit` atualizados (deixam de dizer "exatamente um argumento").
+
+## Prioridade
+
+🔴 Crítico (mudança de API quebrando contrato)
+
+## Dependências
+
+- **Leve** em #88: consome `auditId()` e combina o contrato de envelope (para as linhas de quebra baterem com as linhas normais).
+- **Bloqueia** #90 e #91.
+
+## Estimativa
+
+- **Esforço:** 1-2 dias
+- **Complexidade:** Média

--- a/docs/tasks/task-090-audit-oversize-contingency/Context.md
+++ b/docs/tasks/task-090-audit-oversize-contingency/Context.md
@@ -1,0 +1,111 @@
+# Contexto Técnico - Task #90
+
+## Arquitetura
+
+```mermaid
+flowchart TD
+    A["audit(_msg, body)"] --> B{"byteLen(envelope+body) <= SAFE_LINE_BYTES?"}
+    B -->|sim| C["linha única (Task #89)"]
+    B -->|não| D["splitAuditBody() — Task #88 (puro)"]
+    D --> E["emite cabeçalho (skeleton + marcadores)"]
+    D --> F["emite segmentos (array=JSON / escalar=chunk_part)"]
+    D --> G["this.error(AUDIT_OVERSIZE audit_id=...)"]
+    H["auditChunked(_msg, body) @deprecated"] --> B
+```
+
+> **Mesma contingência, dois pontos de entrada.** A RFC (§9) afirma: "O `audit()`
+> padrão aplica a mesma contingência internamente". `auditChunked()` apenas a
+> torna **explícita, nomeada e `@deprecated`** para facilitar localização/remoção.
+
+## O que muda em `lib/Logger.ts`
+
+### Branch de oversize (linhas ~296-301) — hoje **descarta**
+
+```ts
+// HOJE: descarta silenciosamente
+if (size > DEFAULT_AUDIT_MAX_BYTES) {
+  this.error(`... exceeds the safe limit ...; record dropped`);
+  return;
+}
+```
+
+Passa a: mintar `audit_id`, chamar `splitAuditBody(body, { auditId, limit: SAFE_LINE_BYTES })`,
+emitir cabeçalho + segmentos (cada um com o envelope de auditoria da Task #89), e
+emitir o ERROR `AUDIT_OVERSIZE`. Gatilho passa a ser `SAFE_LINE_BYTES` (~200 KB),
+não os 256 KB.
+
+### Emissão das linhas de quebra (sem `body.0`)
+
+Cada linha (cabeçalho/segmento) é um registro de auditoria **já montado**. A
+emissão **não** pode passar pelo `push()`/`data[i++]` do `json.ts` (reintroduziria
+`body.0`). Recomendado: reusar o mesmo caminho de emissão de auditoria definido na
+Task #89 (que atribui `body` inteiro e monta o envelope), passando cada linha
+pronta. Combinar o mecanismo exato com a Task #89 (decisão "arquitetura de emissão").
+
+### `auditChunked()` — RFC §9 (adaptado)
+
+A RFC mostra uma função livre amarrada a um `logger` de módulo, chamando
+`logger.audit(_msg, body)` no caminho de "coube". Atenção: o `audit()` novo exige
+aridade 2 — `auditChunked` **não** deve depender de detalhes de aridade; deve
+produzir o **mesmo envelope** de `audit('m', body)`. Recomendado expor como
+**método do `Logger`** (`this.error`, `this.tag`, caminho de emissão de auditoria
+já disponíveis), marcado `@deprecated`.
+
+```ts
+/**
+ * @deprecated Contingência temporária para a ferramenta de importação.
+ * Não é um recurso. Quebra um corpo grande em linhas de até ~200KB para evitar
+ * perda silenciosa no Victoria Logs, sempre emitindo um ERROR com o audit_id.
+ * Remover quando a importação passar a auditar por intenção (§7).
+ */
+public auditChunked(_msg: string, body: Record<string, unknown>): void { /* usa splitAuditBody + ERROR */ }
+```
+
+## ERROR `AUDIT_OVERSIZE` (§8)
+
+```text
+ERROR AUDIT_OVERSIZE audit_id=01J8Z9K3F7AB... : o registro excedeu 256KB e precisou
+      ser quebrado em 34 partes. Esta é uma medida de contingência, não um recurso;
+      reduza o volume na origem (auditar a intenção). Consulte a §7.
+```
+
+- nível ERROR (vai ao fluxo operacional → SigNoz, tratado como alerta);
+- contém literal `AUDIT_OVERSIZE`, `audit_id=<id>`, contagem de partes, referência à §7;
+- casa com a consulta §11d.
+
+## Linhas de quebra (§8.1) — formato
+
+```jsonc
+// cabeçalho
+{ "_time":"...", "level":"AUDIT", "severityText":"AUDIT", "severityNumber":12,
+  "tag":"reports", "audit_id":"01J8Z9...", "chunked":true, "chunk_total":34,
+  "_msg":"report.generate",
+  "body": { "action":"report.generate", "user":"alice",
+            "result_csv": { "ref":"body.result_csv", "type":"string", "bytes":5242880, "sha1":"ab12..." } } }
+
+// segmento — array (consultável por json_array_contains_any)
+{ "...envelope...":"...", "audit_id":"01J8Z9...", "chunk_seq":3, "chunk_total":34,
+  "chunk_field":"body.affected_ids", "body": { "affected_ids": ["64f8...e09","..."] } }
+
+// segmento — escalar/blob (reconstruído por concatenação)
+{ "...envelope...":"...", "audit_id":"01J8Z9...", "chunk_seq":7, "chunk_total":34,
+  "chunk_field":"body.result_csv", "chunk_part":"<fração de ~150KB>" }
+```
+
+> Semântica de `chunk_total`/`chunk_seq`: **global** (ver Task #88, resolução da
+> ambiguidade §8.1 × §9).
+
+## Testes — `tests/audit.test.ts` (+ casos novos)
+
+- O teste de oversize atual (linhas ~88-98) deixa de esperar "descarte" e passa a
+  esperar **cabeçalho + segmentos + 1 ERROR**.
+- Casos: marcador `{ref,type,bytes,sha1}` no cabeçalho; segmento array vs escalar;
+  `chunk_seq`/`chunk_total`/`chunk_field`; correlação por `audit_id`; ERROR
+  `AUDIT_OVERSIZE`; estouro por nº de campos; caminho "coube" de `auditChunked`
+  (linha única, sem `chunk_*`, sem ERROR); reconstrução por `chunk_field`.
+
+## Referências
+
+- RFC §8, §8.1, §9, §13 (observabilidade: o ERROR é o principal indicador; integridade verifica `chunk_total`).
+- §8.2 (pasta local): **estudo, não adotada** — não implementar.
+- Task #88 (`splitAuditBody`, `auditId`, `SAFE_LINE_BYTES`); Task #89 (envelope de auditoria).

--- a/docs/tasks/task-090-audit-oversize-contingency/Progress.md
+++ b/docs/tasks/task-090-audit-oversize-contingency/Progress.md
@@ -1,0 +1,25 @@
+# Progresso - Task #90: Contingência de Quebra + ERROR AUDIT_OVERSIZE
+
+## Status Atual
+
+🔴 **Não Iniciado** · Bloqueado por #88 e #89
+
+## Checklist
+
+- [ ] Substituir o branch de descarte (`lib/Logger.ts` ~296-301) pela chamada a `splitAuditBody`
+- [ ] Mintar `audit_id` e gatilhar quebra acima de `SAFE_LINE_BYTES`
+- [ ] Emitir cabeçalho (skeleton + marcadores) com o envelope da Task #89
+- [ ] Emitir segmentos (array → JSON; escalar/blob → `chunk_part`) sem reintroduzir `body.0`
+- [ ] Emitir ERROR `AUDIT_OVERSIZE` (audit_id, contagem, §7) — casa com §11d
+- [ ] Implementar `auditChunked(_msg, body)` `@deprecated` reutilizando o mesmo util
+- [ ] Caminho "coube" do `auditChunked` → linha única, sem `chunk_*`, sem ERROR
+- [ ] Exportar `auditChunked` em `lib/index.ts` (ESM + CJS) e em `LoggerMethods.ts` se método
+- [ ] Tratar estouro por nº de campos (emitir grupos de chaves)
+- [ ] Atualizar JSDoc de `audit`/`DEFAULT_AUDIT_MAX_BYTES`
+- [ ] Testes: quebra, marcador, segmentos, correlação, ERROR, reconstrução, `auditChunked`
+
+## Histórico
+
+| Data | Ação | Resultado |
+|------|------|-----------|
+| 2026-06-25 | Task criada a partir da RFC-OZLOGGER-AUDIT-001 | Aguardando #88 e #89 |

--- a/docs/tasks/task-090-audit-oversize-contingency/Summary.md
+++ b/docs/tasks/task-090-audit-oversize-contingency/Summary.md
@@ -1,0 +1,46 @@
+# Resumo Executivo - Task #90
+
+## Visão Geral
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | task-090 |
+| **GitHub** | [#90](https://github.com/ozmap/logger/issues/90) |
+| **Título** | Contingência de Quebra (`audit`/`auditChunked`) + ERROR `AUDIT_OVERSIZE` |
+| **RFC** | [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §1.3, §3, §8, §9, §13 |
+| **Prioridade** | 🟠 Alta |
+| **Depende de** | #88 (util) **e** #89 (envelope) |
+| **Bloqueia** | — |
+
+## Impacto
+
+Elimina a **perda silenciosa de dados** (hoje corpos grandes são descartados):
+passa a quebrar os valores em linhas seguras, preservando o primeiro nível
+consultável, e emite um ERROR `AUDIT_OVERSIZE` que sinaliza a necessidade de
+correção na origem (auditar a intenção, §7). A `auditChunked()` é **dívida
+técnica explícita** (`@deprecated`), criada para a ferramenta de importação e a
+ser removida quando esta auditar por intenção.
+
+Reforça o requisito do produto: tanto o `audit()` interno quanto a
+`auditChunked()` quebram o log **chamando o mesmo util** (Task #88) — quebra
+idêntica em todo lugar.
+
+## Decisões a confirmar (defaults adotados nos docs)
+
+1. **Escopo da quebra no `audit()` padrão:** o `audit()` executa a contingência
+   **completa** (skeleton, marcadores, segmentos array/escalar, `chunk_*`,
+   estouro por nº de campos), **não** apenas um ERROR mais barulhento. (Maior
+   alavanca de esforço da decomposição — confirmado pela §9.)
+2. **Forma da `auditChunked`:** **método do `Logger`** (acesso a `this.error`,
+   `this.tag`, emissão de auditoria), exportado por `lib/index.ts`. *Alternativa:*
+   função livre com `Logger` injetado.
+3. **Gatilho:** quebra quando `envelope+corpo` excede `SAFE_LINE_BYTES` (~200 KB),
+   substituindo o antigo descarte a 256 KB.
+4. **§8.2 (pasta local):** **não** implementar — é estudo.
+
+## Risco
+
+Alto: é o maior volume de lógica nova e o ponto onde envelope (#89) e util (#88)
+se encontram. Mitigação: util puro testado isoladamente (#88) e envelope de linha
+única já fechado (#89) reduzem a superfície de integração desta task à emissão e
+ao ERROR.

--- a/docs/tasks/task-090-audit-oversize-contingency/Task.md
+++ b/docs/tasks/task-090-audit-oversize-contingency/Task.md
@@ -1,0 +1,82 @@
+# Task #90: Contingência de Quebra (`audit`/`auditChunked`) + ERROR `AUDIT_OVERSIZE`
+
+> RFC: [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §1.3, §3, §8 (8.1), §9, §13
+
+## Objetivo
+
+Substituir o descarte silencioso de corpos grandes pela **contingência de
+quebra** descrita na RFC: quando um registro de auditoria excede o limite
+seguro, o `audit()` quebra os valores em linhas de até ~200 KB (usando o util da
+Task #88), emite cabeçalho + segmentos correlacionados pelo `audit_id`, e
+**sempre** emite um ERROR de alta visibilidade `AUDIT_OVERSIZE`. Adicionalmente,
+expõe a função temporária e `@deprecated` `auditChunked()` para a ferramenta de
+importação (§9), consumindo **o mesmo util** — sem fork de lógica.
+
+## Descrição
+
+Hoje (`lib/Logger.ts`, branch de oversize) um corpo > 256 KB é **descartado**
+com um `this.error(...)` + `return`. A RFC (§8) trata isso como **perda
+silenciosa de dados** e exige contingência:
+
+- "Quebram-se os valores, e não o envelope": o cabeçalho mantém todo o primeiro
+  nível; valores que excederam viram marcador `{ ref, type, bytes, sha1 }`; os
+  dados volumosos vão em linhas de segmento (array → JSON; escalar/blob → `chunk_part`).
+- Toda quebra é uma **condição anômala** → emite ERROR `AUDIT_OVERSIZE` com o
+  `audit_id`, a contagem de partes e referência à §7 (corrigir na origem).
+
+A `auditChunked()` (§9) é a mesma contingência, porém **nomeada e `@deprecated`**,
+para a ferramenta de importação. Quando o corpo cabe, segue o caminho normal de
+linha única (Task #89); quando não cabe, quebra e emite o ERROR. Existe para ser
+**localizável e removível** quando a importação passar a auditar por intenção.
+
+## Escopo
+
+### Inclui
+
+- Substituir o descarte por: `audit_id` + `splitAuditBody()` (Task #88) +
+  emissão de cabeçalho/segmentos + ERROR `AUDIT_OVERSIZE`.
+- Gatilho de quebra = registro (envelope + corpo) acima de `SAFE_LINE_BYTES` (~200 KB).
+- Emissão das linhas de quebra com o **mesmo envelope** da Task #89 (sem `pid`/`ppid`/`traceId`/`spanId`; `_time`; `severityNumber 12`) e **sem reintroduzir `body.0`**.
+- ERROR nível ERROR contendo literal `AUDIT_OVERSIZE`, token `audit_id=<id>`, contagem de partes e referência à §7.
+- Método `auditChunked(_msg, body)` `@deprecated`, reutilizando o mesmo util; caminho de "coube" produz linha única normal.
+- Exportar `auditChunked` em `lib/index.ts` (ESM + CJS).
+- Tratamento de estouro por nº de campos (emitir as linhas de grupos de chaves do util).
+- Atualizar JSDoc/`DEFAULT_AUDIT_MAX_BYTES` (deixa de dizer "descartado").
+
+### Não inclui
+
+- A matemática da quebra em si (Task #88).
+- A assinatura/envelope de linha única (Task #89).
+- Persistência em pasta local — §8.2 é **estudo, não adotado**.
+- Auto-redaction de PII — §13 **proíbe** mascarar no caminho de auditoria.
+
+## Critérios de Aceitação
+
+- [ ] Corpo grande **não é mais descartado:** `audit('m', { blob: 'x'.repeat(300*1024) })`
+      emite cabeçalho + segmento(s) + **exatamente 1** ERROR; **nenhuma** mensagem "record dropped"; total de linhas > 1.
+- [ ] O ERROR é nível ERROR, com `_msg` contendo `AUDIT_OVERSIZE`, `audit_id=<id>`, contagem de partes e referência à §7
+      (consulta §11d `level:=ERROR _msg:~"AUDIT_OVERSIZE"` casa).
+- [ ] **Correlação:** `header.audit_id === ` todos os `segment.audit_id` `=== ` o id no texto do ERROR.
+- [ ] Cabeçalho: `chunked: true`, `chunk_total`, `_msg`; segmentos: `chunk_seq`/`chunk_total`/`chunk_field`;
+      `_msg` presente no cabeçalho e ausente nos segmentos (§8.1).
+- [ ] Linhas de quebra usam o **mesmo util** (Task #88) — sem fork — e o **mesmo envelope** da Task #89
+      (sem `pid`/`ppid`/`traceId`/`spanId`/`host`/`tenant`; `_time` presente; `severityNumber 12`); **sem `body.0`**.
+- [ ] `auditChunked(_msg, body)` existe, é `@deprecated` (JSDoc), reutiliza o mesmo util; para corpo abaixo de
+      `SAFE_LINE_BYTES` produz **uma única** linha normal (sem campos `chunk_*`, sem ERROR).
+- [ ] `auditChunked` exportado em `lib/index.ts` no bloco ESM **e** no `Object.assign` CJS (e em `LoggerMethods.ts` se for método).
+- [ ] Estouro por nº de campos: corpo acima do limite de campos emite múltiplas linhas de grupos de chaves correlacionadas.
+- [ ] JSDoc de `audit`/`DEFAULT_AUDIT_MAX_BYTES` atualizado (quebra, não descarte).
+- [ ] Reconstrução: agrupando segmentos por `chunk_field` e ordenando por `chunk_seq`, recompõe-se o valor original.
+
+## Prioridade
+
+🟠 Alta (resolve perda silenciosa; depende da fundação)
+
+## Dependências
+
+- **Depende de #88** (util de quebra) **e #89** (envelope de linha única).
+
+## Estimativa
+
+- **Esforço:** 2-3 dias
+- **Complexidade:** Alta

--- a/docs/tasks/task-091-audit-rfc-docs/Context.md
+++ b/docs/tasks/task-091-audit-rfc-docs/Context.md
@@ -1,0 +1,41 @@
+# Contexto Técnico - Task #91
+
+## Por que é uma task separada (e opcional)
+
+As seções §7, §10, §11, §12 e §13 da RFC são **orientação ao chamador e
+configuração de ambiente** — o logger não as força em código. Mantê-las fora das
+tasks de código (#88/#89/#90) evita inflar tasks de código com prosa. Se a equipe
+quiser o conjunto **mínimo absoluto**, o conteúdo pode ser absorvido no `Summary`
+da Task #90; recomenda-se, porém, mantê-la separada e de baixa prioridade.
+
+## Pontos do README a corrigir (estado atual → alvo)
+
+| Local (aprox.) | Hoje | Alvo |
+|---|---|---|
+| linha ~400 | `audit(data: unknown)` "apenas UM argumento" | `audit(_msg: string, body: unknown)` |
+| linha ~405 | "aceita exatamente um argumento"; oversize "descartado com ERROR" | dois parâmetros; oversize **quebrado** + ERROR `AUDIT_OVERSIZE` (§8) |
+| linha ~412 | lista de campos a não pôr no corpo | reconciliar: `_msg`/`audit_id` **são** envelope; `traceId`/`spanId`/`host`/`tenant`/`pid`/`ppid` fora da auditoria |
+| linha ~413 | "limita o body a 256KB; acima é descartado" | quebra em linhas ~200KB; nada de descarte silencioso |
+| linha ~414 | dados estruturados | manter, ampliar com §10 (rótulos de baixa cardinalidade) |
+| linha ~610 | `.audit(...messages: any[])` | `.audit(_msg, body)` |
+
+## Conteúdo novo a adicionar
+
+- **§7 Auditar a intenção:** "atualização de N itens correspondentes ao filtro X"
+  em vez da consulta com o array `$in` expandido. A contingência (§8) é exceção, não caminho.
+- **§10 Modelagem:** `body` é achatado em `body.*` pelo Victoria Logs no ingest;
+  use rótulos estáveis (`action`, `entity_type`, `result`); `_stream_fields=tag,level`
+  (config do Victoria Logs — `audit_id`/`body.entity_id` ficam como campos comuns indexados).
+- **§11 LogsQL:** os 4 exemplos da RFC (autoria 24h; conteúdo por `audit_id`;
+  `json_array_contains_any`; ocorrências de `AUDIT_OVERSIZE`).
+- **§12 Matriz:** tabela de "o que vai no corpo / contingência / proibido".
+- **§13 Dados sensíveis:** redigir **só** senha/segredo/token/chave com `filter()`
+  (em `lib/util/Objects.ts`, já exportado); **PII visível**; jamais auto-mascarar
+  no caminho de auditoria (requisito negativo reforçado pela Task #89).
+
+## Observação de consistência
+
+Os exemplos LogsQL e os nomes de campos devem refletir exatamente o que as tasks
+#89 (envelope: `_msg`, `audit_id`, `_time`, `body.*`) e #90 (`chunked`, `chunk_seq`,
+`chunk_total`, `chunk_field`, `AUDIT_OVERSIZE`) emitem. Por isso esta task vem
+**depois** delas.

--- a/docs/tasks/task-091-audit-rfc-docs/Progress.md
+++ b/docs/tasks/task-091-audit-rfc-docs/Progress.md
@@ -1,0 +1,23 @@
+# Progresso - Task #91: Documentação do Padrão de Auditoria
+
+## Status Atual
+
+🟢 **Não Iniciado** · Opcional · Idealmente após #89/#90
+
+## Checklist
+
+- [ ] Atualizar assinatura no README (linhas ~400, ~405, ~610) → `audit(_msg, body)`
+- [ ] Trocar "descartado" por "quebrado + ERROR AUDIT_OVERSIZE" (linhas ~405, ~413)
+- [ ] Reconciliar a lista de campos do corpo (linha ~412) com `_msg`/`audit_id`
+- [ ] Adicionar §7 (auditar a intenção)
+- [ ] Adicionar §10 (modelagem / `_stream_fields=tag,level`)
+- [ ] Adicionar §11 (exemplos LogsQL a/b/c/d)
+- [ ] Adicionar §12 (matriz de decisão do corpo)
+- [ ] Adicionar §13 (dados sensíveis: `filter()` p/ segredos; PII visível; sem auto-máscara)
+- [ ] Conferir coerência dos exemplos com os campos emitidos por #89/#90
+
+## Histórico
+
+| Data | Ação | Resultado |
+|------|------|-----------|
+| 2026-06-25 | Task criada a partir da RFC-OZLOGGER-AUDIT-001 | Aguardando #89/#90 |

--- a/docs/tasks/task-091-audit-rfc-docs/Summary.md
+++ b/docs/tasks/task-091-audit-rfc-docs/Summary.md
@@ -1,0 +1,33 @@
+# Resumo Executivo - Task #91
+
+## Visão Geral
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | task-091 |
+| **GitHub** | [#91](https://github.com/ozmap/logger/issues/91) |
+| **Título** | Documentação do Padrão de Auditoria (RFC-001) |
+| **RFC** | [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §7, §10, §11, §12, §13 |
+| **Prioridade** | 🟢 Baixa (opcional / doc-only) |
+| **Depende de** | #89 (nomes de campos); idealmente após #90 |
+| **Bloqueia** | — |
+
+## Impacto
+
+Fecha a entrega da RFC para o consumidor: documenta a nova assinatura, o fim do
+`body.0`, o princípio de auditar a intenção, a modelagem para consulta e a
+política de dados sensíveis. Sem isso, o README continuaria descrevendo o
+comportamento antigo (1 argumento, descarte no oversize) — informação incorreta
+após #89/#90.
+
+## Decisão a confirmar
+
+- **Manter como task separada vs. absorver na #90.** Para o conjunto **mínimo
+  absoluto**, pode ser dobrada no escopo da Task #90. Recomendação: manter
+  separada e de baixa prioridade — é prosa, sem dependência de código além dos
+  nomes finais de campos.
+
+## Risco
+
+Muito baixo (doc-only). Único cuidado: os exemplos LogsQL e nomes de campos devem
+espelhar exatamente o que #89/#90 emitem — por isso vem depois delas.

--- a/docs/tasks/task-091-audit-rfc-docs/Task.md
+++ b/docs/tasks/task-091-audit-rfc-docs/Task.md
@@ -1,0 +1,63 @@
+# Task #91: Documentação do Padrão de Auditoria (RFC-001)
+
+> RFC: [RFC-OZLOGGER-AUDIT-001](../../rfc/RFC-OZLOGGER-AUDIT-001.md) §7, §10, §11, §12, §13
+> **Opcional / pode ser absorvida** pelas tasks de código se a equipe quiser o conjunto mínimo absoluto.
+
+## Objetivo
+
+Atualizar a documentação do consumidor (README) para o novo padrão de auditoria:
+nova assinatura, fim do `body.0`, princípio de **auditar a intenção**, modelagem
+para consulta (LogsQL / `_stream_fields`), matriz de decisão do corpo e a política
+de dados sensíveis. São conteúdos **doc-only** da RFC — não geram código no logger.
+
+## Descrição
+
+O README documenta hoje o comportamento **antigo** e agora **incorreto**:
+
+- linha ~400 e ~405: "`audit()` aceita **exatamente um argumento**";
+- linha ~405 e ~413: body acima do limite é "**descartado** com um ERROR";
+- linha ~412: lista de campos a não incluir no corpo (a reconciliar com `_msg`/`audit_id`);
+- linha ~610: assinatura antiga em `.audit(...)`.
+
+Esta task alinha o README à RFC e adiciona a orientação de uso que o logger **não
+pode forçar** (cabe ao chamador), fechando a entrega da RFC para quem consome o pacote.
+
+## Escopo
+
+### Inclui (tudo em `README.md`, doc-only)
+
+- **Assinatura:** `audit(_msg: string, body: unknown)` (substitui "exatamente um argumento"); corpo vira `body.*`, fim do `body.0`; `_msg` e `audit_id` no envelope.
+- **Oversize:** trocar "descartado" por "**quebrado** em linhas seguras + ERROR `AUDIT_OVERSIZE`" (§8); reconciliar a lista da linha ~412 com os novos campos de envelope.
+- **§7 Auditar a intenção:** registrar filtro + contagem, não identificadores resolvidos; nunca logar a consulta bruta expandida.
+- **§10 Modelagem para consulta:** rótulos estáveis de baixa cardinalidade; dados estruturados; recomendação `_stream_fields=tag,level` (config do Victoria Logs, **não** do logger).
+- **§11 Consultas (LogsQL):** exemplos a/b/c/d (incl. `json_array_contains_any` e `_msg:~"AUDIT_OVERSIZE"`).
+- **§12 Matriz de decisão do corpo:** o que vai inline, o que vira contingência, o que é proibido.
+- **§13 Dados sensíveis:** redigir **apenas** senhas/segredos/tokens/chaves via `filter()` (já exportado); **e-mail, CPF e PII permanecem visíveis** (auditoria local, um tenant). **Nunca** mascarar PII no caminho de auditoria.
+
+### Não inclui
+
+- Qualquer mudança de código (coberta por #88/#89/#90).
+- Configuração de servidor Victoria Logs / Fluent Bit (ambiente do cliente).
+
+## Critérios de Aceitação
+
+- [ ] README não afirma mais "exatamente um argumento" nem "descartado" para oversize.
+- [ ] Seção da assinatura mostra `audit(_msg, body)` e exemplo de envelope com `_msg`/`audit_id`/`body.*`.
+- [ ] Seção "Auditoria e bases de logs" cobre §7, §10, §11, §12, §13.
+- [ ] Linha ~412 reconciliada: deixa claro que `_msg`/`audit_id` **fazem** parte do envelope e que `traceId`/`spanId`/`host`/`tenant`/`pid`/`ppid` **não** integram a auditoria (tratados no Fluent Bit / só no `body` se o produto exigir).
+- [ ] Política de dados sensíveis explícita: `filter()` para senhas/segredos; PII visível; sem auto-máscara.
+- [ ] Exemplos LogsQL presentes e coerentes com os campos realmente emitidos pelas tasks #89/#90.
+- [ ] Assinatura na referência rápida (linha ~610) atualizada.
+
+## Prioridade
+
+🟢 Baixa (doc-only; sem bloqueio de deploy)
+
+## Dependências
+
+- **Depende de #89** (nomes finais de campos: `_msg`, `audit_id`, `_time`, `body.*`). Idealmente após #90 para documentar o ERROR/quebra com fidelidade.
+
+## Estimativa
+
+- **Esforço:** 0,5 dia
+- **Complexidade:** Baixa

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,17 @@
 import { createLogger, Logger } from './Logger';
 import { mask, filter } from './util/Objects';
 import {
+	SAFE_LINE_BYTES,
+	auditId,
+	byteLen,
+	heavyMarker,
+	splitFirstLevel,
+	chunkArrayByBytes,
+	chunkStringByBytes,
+	countChunks,
+	splitAuditBody
+} from './util/AuditChunk';
+import {
 	getServerPort,
 	getServerInstance,
 	resetServerState
@@ -9,6 +20,17 @@ import {
 // Re-export for ESM
 export { createLogger, Logger };
 export { mask, filter };
+export {
+	SAFE_LINE_BYTES,
+	auditId,
+	byteLen,
+	heavyMarker,
+	splitFirstLevel,
+	chunkArrayByBytes,
+	chunkStringByBytes,
+	countChunks,
+	splitAuditBody
+};
 export { getServerPort, getServerInstance, resetServerState };
 
 // Default export for ESM
@@ -20,6 +42,15 @@ const moduleExport = Object.assign(createLogger, {
 	Logger,
 	mask,
 	filter,
+	SAFE_LINE_BYTES,
+	auditId,
+	byteLen,
+	heavyMarker,
+	splitFirstLevel,
+	chunkArrayByBytes,
+	chunkStringByBytes,
+	countChunks,
+	splitAuditBody,
 	getServerPort,
 	getServerInstance,
 	resetServerState,

--- a/lib/util/AuditChunk.ts
+++ b/lib/util/AuditChunk.ts
@@ -32,7 +32,7 @@ export type HeavyMarker = {
  */
 export type AuditChunkHeader = {
 	body: Record<string, unknown>;
-	chunked: true;
+	chunked: boolean;
 	chunk_total: number;
 };
 
@@ -229,6 +229,14 @@ export function chunkStringByBytes(str: string, limit: number): string[] {
 			while (end > offset && (buf[end] & 0xc0) === 0x80) end--;
 		}
 
+		// If the limit is smaller than the character at `offset`, the back-off
+		// collapses to `offset`. Emit one whole character anyway so progress is
+		// guaranteed and the loop can never spin forever on a tiny limit.
+		if (end === offset) {
+			end = offset + 1;
+			while (end < buf.length && (buf[end] & 0xc0) === 0x80) end++;
+		}
+
 		parts.push(buf.toString('utf8', offset, end));
 		offset = end;
 	}
@@ -313,7 +321,13 @@ function chunkField(
 	const ref = `body.${field}`;
 
 	if (Array.isArray(value)) {
-		return chunkArrayByBytes(value, limit).map((part) => ({
+		// Array parts are emitted wrapped as `{ "<field>": [...] }`. Reserve the
+		// wrapper bytes (`{"<field>":` + `}`) so the emitted segment — not just
+		// the bare array — stays within the limit.
+		const wrapperBytes = byteLen(`{"${field}":}`);
+		const arrayLimit = Math.max(2, limit - wrapperBytes);
+
+		return chunkArrayByBytes(value, arrayLimit).map((part) => ({
 			chunk_field: ref,
 			body: { [field]: part }
 		}));
@@ -430,7 +444,7 @@ export function splitAuditBody(
 	});
 
 	return {
-		header: { body: headerBody, chunked: true, chunk_total },
+		header: { body: headerBody, chunked: chunk_total > 0, chunk_total },
 		segments
 	};
 }

--- a/lib/util/AuditChunk.ts
+++ b/lib/util/AuditChunk.ts
@@ -1,0 +1,436 @@
+import { createHash, randomBytes } from 'crypto';
+import { getCircularReplacer, isJsonObject } from './Helpers';
+
+/**
+ * Safe maximum size, in bytes, for a single audit line.
+ *
+ * VictoriaLogs drops any line larger than its `-insert.maxLineSizeBytes`
+ * (262144 bytes / 256KiB by default) to protect memory. We break oversized
+ * bodies into lines that stay below this value, leaving a margin under the
+ * 256KiB hard limit so the serialized envelope plus chunk metadata still fits.
+ */
+export const SAFE_LINE_BYTES = 200 * 1024;
+
+/**
+ * Crockford's Base32 alphabet (ULID encoding), excluding I, L, O and U.
+ */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/**
+ * Marker that replaces an oversized value in the chunk header skeleton.
+ */
+export type HeavyMarker = {
+	ref: string;
+	type: string;
+	bytes: number;
+	sha1: string;
+};
+
+/**
+ * Header line of a broken audit record: the full first level of the body with
+ * oversized values replaced by {@link HeavyMarker}s.
+ */
+export type AuditChunkHeader = {
+	body: Record<string, unknown>;
+	chunked: true;
+	chunk_total: number;
+};
+
+/**
+ * Segment line carrying a slice of an oversized array field as queryable JSON.
+ */
+export type AuditArraySegment = {
+	chunk_seq: number;
+	chunk_total: number;
+	chunk_field: string;
+	body: Record<string, unknown>;
+};
+
+/**
+ * Segment line carrying a text fraction of an oversized scalar/blob field.
+ */
+export type AuditTextSegment = {
+	chunk_seq: number;
+	chunk_total: number;
+	chunk_field: string;
+	chunk_part: string;
+};
+
+/**
+ * Any segment line produced when breaking an audit body.
+ */
+export type AuditChunkSegment = AuditArraySegment | AuditTextSegment;
+
+/**
+ * Result of {@link splitAuditBody}: a header line plus the ordered segments.
+ */
+export type SplitAuditResult = {
+	header: AuditChunkHeader;
+	segments: AuditChunkSegment[];
+};
+
+/**
+ * Options accepted by {@link splitAuditBody}.
+ */
+export type SplitAuditOptions = {
+	limit?: number;
+	maxFields?: number;
+};
+
+/**
+ * Serializes a value to the string used for sizing and chunking. Strings are
+ * returned as-is; everything else is JSON-stringified with circular-safe
+ * handling. Values that JSON.stringify drops (undefined, functions) become ''.
+ *
+ * @param   value  The value to serialize.
+ * @returns The string representation used for byte measurement and chunking.
+ */
+function serialize(value: unknown): string {
+	if (typeof value === 'string') return value;
+
+	const result = JSON.stringify(value, getCircularReplacer());
+
+	return result === undefined ? '' : result;
+}
+
+/**
+ * Measures the UTF-8 byte length of a value's serialized form.
+ *
+ * @param   value  The value to measure.
+ * @returns The number of UTF-8 bytes of the serialized value.
+ */
+export function byteLen(value: unknown): number {
+	return Buffer.byteLength(serialize(value), 'utf8');
+}
+
+/**
+ * Measures the UTF-8 byte length of a value as it appears inside JSON (strings
+ * include their surrounding quotes). Used to size array elements accurately
+ * when packing them into chunks.
+ *
+ * @param   value  The value to measure as a JSON token.
+ * @returns The number of UTF-8 bytes of the value's JSON representation.
+ */
+function jsonByteLen(value: unknown): number {
+	const result = JSON.stringify(value, getCircularReplacer());
+
+	return Buffer.byteLength(result === undefined ? 'null' : result, 'utf8');
+}
+
+/**
+ * Generates an audit identifier as a 26-character ULID (Crockford Base32):
+ * 48 bits of millisecond timestamp followed by 80 bits of randomness. Uses
+ * node's crypto only, so it adds no runtime dependency.
+ *
+ * @returns A new ULID string used to correlate audit lines.
+ */
+export function auditId(): string {
+	let time = Date.now();
+	const chars: string[] = new Array(26);
+
+	// 48-bit timestamp -> 10 Base32 chars (most significant first).
+	for (let i = 9; i >= 0; i--) {
+		chars[i] = CROCKFORD[time % 32];
+		time = Math.floor(time / 32);
+	}
+
+	// 80 bits of randomness -> 16 Base32 chars.
+	const random = randomBytes(10);
+	let bits = 0;
+	let acc = 0;
+	let pos = 10;
+
+	for (let i = 0; i < random.length; i++) {
+		acc = (acc << 8) | random[i];
+		bits += 8;
+
+		while (bits >= 5) {
+			bits -= 5;
+			chars[pos++] = CROCKFORD[(acc >>> bits) & 31];
+		}
+
+		acc &= (1 << bits) - 1;
+	}
+
+	return chars.join('');
+}
+
+/**
+ * Builds the marker that replaces an oversized value in the header skeleton.
+ * The marker stays small and queryable while recording how to verify the
+ * reconstructed value (`bytes` and `sha1` of the original serialized value).
+ *
+ * @param   field  The first-level field name the value belongs to.
+ * @param   value  The oversized value being replaced.
+ * @returns The marker object describing the removed value.
+ */
+export function heavyMarker(field: string, value: unknown): HeavyMarker {
+	const serialized = serialize(value);
+
+	return {
+		ref: `body.${field}`,
+		type: Array.isArray(value) ? 'array' : typeof value,
+		bytes: Buffer.byteLength(serialized, 'utf8'),
+		sha1: createHash('sha1').update(serialized).digest('hex')
+	};
+}
+
+/**
+ * Splits an array into sub-arrays whose serialized size stays under `limit`.
+ * The division is by bytes, never by item count; an element larger than the
+ * limit on its own is emitted alone (an array element cannot be split).
+ *
+ * @param   arr    The array to split.
+ * @param   limit  The maximum serialized size, in bytes, per sub-array.
+ * @returns The ordered list of sub-arrays.
+ */
+export function chunkArrayByBytes(arr: unknown[], limit: number): unknown[][] {
+	const parts: unknown[][] = [];
+	let current: unknown[] = [];
+	let size = 2; // accounts for the enclosing '[' and ']'
+
+	for (const item of arr) {
+		const itemBytes = jsonByteLen(item) + 1; // + ',' separator
+
+		if (current.length > 0 && size + itemBytes > limit) {
+			parts.push(current);
+			current = [];
+			size = 2;
+		}
+
+		current.push(item);
+		size += itemBytes;
+	}
+
+	if (current.length > 0) parts.push(current);
+
+	return parts;
+}
+
+/**
+ * Splits a string into fractions whose UTF-8 byte size stays under `limit`,
+ * never cutting in the middle of a multi-byte character.
+ *
+ * @param   str    The string to split.
+ * @param   limit  The maximum size, in bytes, per fraction.
+ * @returns The ordered list of string fractions.
+ */
+export function chunkStringByBytes(str: string, limit: number): string[] {
+	const parts: string[] = [];
+	const buf = Buffer.from(str, 'utf8');
+	let offset = 0;
+
+	while (offset < buf.length) {
+		let end = Math.min(offset + limit, buf.length);
+
+		// Back off so we never split a multi-byte UTF-8 sequence: 0b10xxxxxx
+		// bytes are continuation bytes.
+		if (end < buf.length) {
+			while (end > offset && (buf[end] & 0xc0) === 0x80) end--;
+		}
+
+		parts.push(buf.toString('utf8', offset, end));
+		offset = end;
+	}
+
+	return parts;
+}
+
+/**
+ * Separates the first level of a body into a header skeleton and the heavy
+ * values that must be chunked. A value is heavy when it alone exceeds `limit`;
+ * additionally, the largest inline values are moved out until the skeleton
+ * itself fits, covering the case of many medium values summing past the limit.
+ *
+ * @param   body   The audit body (a plain object).
+ * @param   limit  The maximum serialized size, in bytes, per line.
+ * @returns The skeleton (markers in place of heavy values) and the heavy entries.
+ */
+export function splitFirstLevel(
+	body: Record<string, unknown>,
+	limit: number
+): { skeleton: Record<string, unknown>; heavy: Array<[string, unknown]> } {
+	const skeleton: Record<string, unknown> = {};
+	const heavyKeys = new Set<string>();
+
+	for (const [key, value] of Object.entries(body)) {
+		if (byteLen(value) > limit) {
+			heavyKeys.add(key);
+			skeleton[key] = heavyMarker(key, value);
+		} else {
+			skeleton[key] = value;
+		}
+	}
+
+	// Move the largest remaining inline fields out until the skeleton fits.
+	while (byteLen(skeleton) > limit) {
+		const candidates = Object.keys(body).filter((k) => !heavyKeys.has(k));
+
+		if (candidates.length === 0) break;
+
+		let largest = candidates[0];
+		let largestBytes = byteLen(body[largest]);
+
+		for (const key of candidates) {
+			const bytes = byteLen(body[key]);
+
+			if (bytes > largestBytes) {
+				largest = key;
+				largestBytes = bytes;
+			}
+		}
+
+		heavyKeys.add(largest);
+		skeleton[largest] = heavyMarker(largest, body[largest]);
+	}
+
+	const heavy: Array<[string, unknown]> = [...heavyKeys].map((key) => [
+		key,
+		body[key]
+	]);
+
+	return { skeleton, heavy };
+}
+
+/**
+ * Breaks a single heavy field into segment lines. Arrays become queryable JSON
+ * fractions (`body`); everything else becomes text fractions (`chunk_part`).
+ *
+ * @param   field  The first-level field name.
+ * @param   value  The heavy value to break.
+ * @param   limit  The maximum serialized size, in bytes, per segment.
+ * @returns The ordered segment payloads (without sequencing metadata yet).
+ */
+function chunkField(
+	field: string,
+	value: unknown,
+	limit: number
+): Array<{
+	chunk_field: string;
+	body?: Record<string, unknown>;
+	chunk_part?: string;
+}> {
+	const ref = `body.${field}`;
+
+	if (Array.isArray(value)) {
+		return chunkArrayByBytes(value, limit).map((part) => ({
+			chunk_field: ref,
+			body: { [field]: part }
+		}));
+	}
+
+	return chunkStringByBytes(serialize(value), limit).map((part) => ({
+		chunk_field: ref,
+		chunk_part: part
+	}));
+}
+
+/**
+ * Counts how many segment lines the heavy entries will produce.
+ *
+ * @param   heavy  The heavy entries returned by {@link splitFirstLevel}.
+ * @param   limit  The maximum serialized size, in bytes, per segment.
+ * @returns The total number of segment lines for the heavy entries.
+ */
+export function countChunks(
+	heavy: Array<[string, unknown]>,
+	limit: number = SAFE_LINE_BYTES
+): number {
+	let total = 0;
+
+	for (const [field, value] of heavy) {
+		total += chunkField(field, value, limit).length;
+	}
+
+	return total;
+}
+
+/**
+ * Breaks an oversized audit body into a header line plus segment lines, as
+ * plain data. This function has no side effects: it never writes to stdout and
+ * never formats output — the caller is responsible for adding the envelope
+ * (audit_id, _time, level, ...) and emitting each line. Sharing this single
+ * implementation guarantees every consumer breaks audit logs identically.
+ *
+ * Sequencing is global: `chunk_seq` is a 0-based index across all segments and
+ * `chunk_total` is the total number of segment lines (header and segments carry
+ * the same `chunk_total`).
+ *
+ * @param   body  The audit body to break (must be a plain object).
+ * @param   opts  Splitting options (`limit` and `maxFields`).
+ * @returns The header line and the ordered segment lines.
+ */
+export function splitAuditBody(
+	body: unknown,
+	opts: SplitAuditOptions = {}
+): SplitAuditResult {
+	const limit = opts.limit ?? SAFE_LINE_BYTES;
+	const maxFields = opts.maxFields ?? 900;
+
+	if (!isJsonObject(body)) {
+		throw new TypeError('splitAuditBody requires a plain object body');
+	}
+
+	const record = body as Record<string, unknown>;
+	const { skeleton, heavy } = splitFirstLevel(record, limit);
+
+	const specs: Array<{
+		chunk_field: string;
+		body?: Record<string, unknown>;
+		chunk_part?: string;
+	}> = [];
+
+	for (const [field, value] of heavy) {
+		specs.push(...chunkField(field, value, limit));
+	}
+
+	// Field-count overflow: VictoriaLogs caps fields per entry, so a body with
+	// too many first-level keys spreads the extra keys across segment lines.
+	let headerBody = skeleton;
+	const keys = Object.keys(skeleton);
+
+	if (keys.length > maxFields) {
+		headerBody = {};
+
+		for (const key of keys.slice(0, maxFields)) {
+			headerBody[key] = skeleton[key];
+		}
+
+		const overflow = keys.slice(maxFields);
+
+		for (let i = 0; i < overflow.length; i += maxFields) {
+			const group: Record<string, unknown> = {};
+
+			for (const key of overflow.slice(i, i + maxFields)) {
+				group[key] = skeleton[key];
+			}
+
+			specs.push({ chunk_field: '(fields)', body: group });
+		}
+	}
+
+	const chunk_total = specs.length;
+
+	const segments: AuditChunkSegment[] = specs.map((spec, index) => {
+		if (spec.body !== undefined) {
+			return {
+				chunk_seq: index,
+				chunk_total,
+				chunk_field: spec.chunk_field,
+				body: spec.body
+			};
+		}
+
+		return {
+			chunk_seq: index,
+			chunk_total,
+			chunk_field: spec.chunk_field,
+			chunk_part: spec.chunk_part as string
+		};
+	});
+
+	return {
+		header: { body: headerBody, chunked: true, chunk_total },
+		segments
+	};
+}

--- a/tests/auditChunk.test.ts
+++ b/tests/auditChunk.test.ts
@@ -128,6 +128,17 @@ describe('AuditChunk (reusable pure split util)', () => {
 			}
 			expect(parts.join('')).toBe(str);
 		});
+
+		test('terminates and round-trips when the limit is smaller than a character', () => {
+			// A 4-byte emoji with a 3-byte limit cannot fit; the chunker must
+			// still make progress (emit the whole character) instead of looping.
+			const parts = chunkStringByBytes('😀', 3);
+			expect(parts).toEqual(['😀']);
+
+			const many = chunkStringByBytes('😀😀😀', 1);
+			expect(many).toEqual(['😀', '😀', '😀']);
+			expect(many.join('')).toBe('😀😀😀');
+		});
 	});
 
 	describe('splitFirstLevel', () => {
@@ -180,9 +191,12 @@ describe('AuditChunk (reusable pure split util)', () => {
 	describe('countChunks', () => {
 		test('counts the segments the heavy entries will produce', () => {
 			const arr = Array.from({ length: 5000 }, (_, i) => `id-${i}`);
-			const heavy: Array<[string, unknown]> = [['ids', arr]];
-			const expected = chunkArrayByBytes(arr, 1024).length;
-			expect(countChunks(heavy, 1024)).toBe(expected);
+			const body = { ids: arr };
+			// countChunks must agree with the segments splitAuditBody emits,
+			// since both go through the same per-field chunking.
+			const { heavy } = splitFirstLevel(body, 1024);
+			const { segments } = splitAuditBody(body, { limit: 1024 });
+			expect(countChunks(heavy, 1024)).toBe(segments.length);
 		});
 	});
 
@@ -216,6 +230,11 @@ describe('AuditChunk (reusable pure split util)', () => {
 				expect(seg.chunk_field).toBe('body.affected_ids');
 				expect('body' in seg).toBe(true);
 				expect('chunk_part' in seg).toBe(false);
+				// The EMITTED segment body (wrapper included), not just the bare
+				// array, must stay within the limit.
+				expect(
+					byteLen((seg as { body: Record<string, unknown> }).body)
+				).toBeLessThanOrEqual(16 * 1024);
 			});
 
 			// Reconstruction: concatenate the array slices in order.
@@ -250,6 +269,63 @@ describe('AuditChunk (reusable pure split util)', () => {
 				.map((seg) => (seg as { chunk_part: string }).chunk_part)
 				.join('');
 			expect(rebuilt).toBe(blob);
+
+			// The marker's bytes/sha1 must verify the reconstructed value
+			// end-to-end (the whole point of the marker — RFC §8.1 / §13).
+			const marker = header.body.result_csv as {
+				bytes: number;
+				sha1: string;
+			};
+			expect(Buffer.byteLength(rebuilt, 'utf8')).toBe(marker.bytes);
+			expect(createHash('sha1').update(rebuilt).digest('hex')).toBe(
+				marker.sha1
+			);
+		});
+
+		test('marks chunked:false / chunk_total:0 when nothing needs breaking', () => {
+			const { header, segments } = splitAuditBody({
+				action: 'login',
+				user: 'alice'
+			});
+
+			expect(header.chunked).toBe(false);
+			expect(header.chunk_total).toBe(0);
+			expect(segments).toHaveLength(0);
+			// The first level is preserved inline (no markers).
+			expect(header.body).toEqual({ action: 'login', user: 'alice' });
+		});
+
+		test('uses one global chunk_seq across a mixed array + scalar body', () => {
+			const ids = Array.from({ length: 20000 }, (_, i) => `id-${i}`);
+			const blob = 'y'.repeat(40 * 1024);
+			const { header, segments } = splitAuditBody(
+				{ action: 'bulk', affected_ids: ids, result_csv: blob },
+				{ limit: 16 * 1024 }
+			);
+
+			// chunk_seq must be contiguous and unique 0..chunk_total-1 across
+			// BOTH fields (global sequencing, not per-field).
+			expect(segments.map((s) => s.chunk_seq)).toEqual(
+				Array.from({ length: header.chunk_total }, (_, i) => i)
+			);
+
+			// Each field reconstructs from its own chunk_field group.
+			const arr = segments
+				.filter((s) => s.chunk_field === 'body.affected_ids')
+				.sort((a, b) => a.chunk_seq - b.chunk_seq)
+				.flatMap(
+					(s) =>
+						(s as { body: Record<string, unknown> }).body
+							.affected_ids as unknown[]
+				);
+			expect(arr).toEqual(ids);
+
+			const text = segments
+				.filter((s) => s.chunk_field === 'body.result_csv')
+				.sort((a, b) => a.chunk_seq - b.chunk_seq)
+				.map((s) => (s as { chunk_part: string }).chunk_part)
+				.join('');
+			expect(text).toBe(blob);
 		});
 
 		test('spreads first-level keys across lines on field-count overflow', () => {

--- a/tests/auditChunk.test.ts
+++ b/tests/auditChunk.test.ts
@@ -1,0 +1,280 @@
+import { expect, describe, test, jest } from '@jest/globals';
+// Import the util DIRECTLY (not through ../lib) to prove it is usable without
+// the Logger and produces no side effects.
+import {
+	SAFE_LINE_BYTES,
+	auditId,
+	byteLen,
+	heavyMarker,
+	splitFirstLevel,
+	chunkArrayByBytes,
+	chunkStringByBytes,
+	countChunks,
+	splitAuditBody
+} from '../lib/util/AuditChunk';
+import { createHash } from 'crypto';
+
+describe('AuditChunk (reusable pure split util)', () => {
+	describe('purity / reusability', () => {
+		test('produces no stdout/stderr output when run', () => {
+			const out = jest
+				.spyOn(process.stdout, 'write')
+				.mockImplementation(() => true);
+			const err = jest
+				.spyOn(process.stderr, 'write')
+				.mockImplementation(() => true);
+
+			splitAuditBody({ blob: 'x'.repeat(SAFE_LINE_BYTES + 10) });
+			chunkArrayByBytes([1, 2, 3], 1024);
+			chunkStringByBytes('abc', 1024);
+			auditId();
+			byteLen({ a: 1 });
+
+			expect(out).not.toHaveBeenCalled();
+			expect(err).not.toHaveBeenCalled();
+
+			out.mockRestore();
+			err.mockRestore();
+		});
+
+		test('SAFE_LINE_BYTES is 200KB', () => {
+			expect(SAFE_LINE_BYTES).toBe(200 * 1024);
+		});
+	});
+
+	describe('auditId', () => {
+		test('returns a 26-char Crockford Base32 ULID', () => {
+			const id = auditId();
+			expect(id).toHaveLength(26);
+			expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+		});
+
+		test('returns distinct ids on consecutive calls', () => {
+			const ids = new Set(Array.from({ length: 100 }, () => auditId()));
+			expect(ids.size).toBe(100);
+		});
+	});
+
+	describe('byteLen', () => {
+		test('measures UTF-8 bytes of the serialized value', () => {
+			expect(byteLen('abc')).toBe(3);
+			expect(byteLen('café')).toBe(5); // é is 2 bytes
+			expect(byteLen({ a: 1 })).toBe(Buffer.byteLength('{"a":1}'));
+		});
+	});
+
+	describe('heavyMarker', () => {
+		test('builds { ref, type, bytes, sha1 } for a string', () => {
+			const value = 'x'.repeat(1000);
+			const marker = heavyMarker('result_csv', value);
+
+			expect(marker).toEqual({
+				ref: 'body.result_csv',
+				type: 'string',
+				bytes: 1000,
+				sha1: createHash('sha1').update(value).digest('hex')
+			});
+		});
+
+		test('reports type "array" for arrays', () => {
+			const marker = heavyMarker('ids', [1, 2, 3]);
+			expect(marker.type).toBe('array');
+			expect(marker.ref).toBe('body.ids');
+		});
+	});
+
+	describe('chunkArrayByBytes', () => {
+		test('splits by bytes and the parts concatenate back to the original', () => {
+			const arr = Array.from({ length: 5000 }, (_, i) => `id-${i}`);
+			const parts = chunkArrayByBytes(arr, 1024);
+
+			expect(parts.length).toBeGreaterThan(1);
+			for (const part of parts) {
+				expect(byteLen(part)).toBeLessThanOrEqual(1024);
+			}
+			expect(parts.flat()).toEqual(arr);
+		});
+
+		test('keeps an oversized single element alone', () => {
+			const big = 'x'.repeat(2048);
+			const parts = chunkArrayByBytes(['a', big, 'b'], 1024);
+			expect(parts.flat()).toEqual(['a', big, 'b']);
+			expect(parts.some((p) => p.length === 1 && p[0] === big)).toBe(
+				true
+			);
+		});
+	});
+
+	describe('chunkStringByBytes', () => {
+		test('splits by bytes and concatenates back to the original', () => {
+			const str = 'x'.repeat(5000);
+			const parts = chunkStringByBytes(str, 1024);
+
+			expect(parts.length).toBe(5);
+			for (const part of parts) {
+				expect(Buffer.byteLength(part, 'utf8')).toBeLessThanOrEqual(
+					1024
+				);
+			}
+			expect(parts.join('')).toBe(str);
+		});
+
+		test('never splits a multi-byte UTF-8 character', () => {
+			const str = '😀'.repeat(500); // each emoji is 4 bytes
+			const parts = chunkStringByBytes(str, 10);
+
+			for (const part of parts) {
+				expect(Buffer.byteLength(part, 'utf8')).toBeLessThanOrEqual(10);
+			}
+			expect(parts.join('')).toBe(str);
+		});
+	});
+
+	describe('splitFirstLevel', () => {
+		test('keeps small values inline and marks oversized values', () => {
+			const big = 'x'.repeat(SAFE_LINE_BYTES + 10);
+			const { skeleton, heavy } = splitFirstLevel(
+				{ action: 'report', user: 'alice', result_csv: big },
+				SAFE_LINE_BYTES
+			);
+
+			expect(skeleton.action).toBe('report');
+			expect(skeleton.user).toBe('alice');
+			expect(skeleton.result_csv).toEqual({
+				ref: 'body.result_csv',
+				type: 'string',
+				bytes: SAFE_LINE_BYTES + 10,
+				sha1: createHash('sha1').update(big).digest('hex')
+			});
+			expect(heavy.map(([k]) => k)).toEqual(['result_csv']);
+		});
+
+		test('moves out the largest field when many medium values overflow', () => {
+			// No single field exceeds the limit, but together they do. The
+			// values are large enough that replacing one with a marker (~85
+			// bytes) brings the skeleton back under the limit.
+			const body = {
+				a: 'a'.repeat(500),
+				b: 'b'.repeat(1500),
+				c: 'c'.repeat(500)
+			};
+			const { skeleton, heavy } = splitFirstLevel(body, 2000);
+
+			expect(byteLen(skeleton)).toBeLessThanOrEqual(2000);
+			// 'b' is the largest and is the first to be moved out.
+			expect(heavy.map(([k]) => k)).toContain('b');
+		});
+
+		test('stops when only markers remain (cannot shrink further)', () => {
+			const body = {
+				a: 'a'.repeat(40),
+				b: 'b'.repeat(40)
+			};
+			// Tiny limit forces every field to become a marker.
+			const { skeleton, heavy } = splitFirstLevel(body, 5);
+			expect(heavy.length).toBe(2);
+			expect((skeleton.a as { ref: string }).ref).toBe('body.a');
+		});
+	});
+
+	describe('countChunks', () => {
+		test('counts the segments the heavy entries will produce', () => {
+			const arr = Array.from({ length: 5000 }, (_, i) => `id-${i}`);
+			const heavy: Array<[string, unknown]> = [['ids', arr]];
+			const expected = chunkArrayByBytes(arr, 1024).length;
+			expect(countChunks(heavy, 1024)).toBe(expected);
+		});
+	});
+
+	describe('splitAuditBody', () => {
+		test('throws on a non-object body', () => {
+			expect(() => splitAuditBody('a string')).toThrow(
+				/plain object body/
+			);
+			expect(() => splitAuditBody([1, 2, 3])).toThrow(
+				/plain object body/
+			);
+		});
+
+		test('breaks an oversized array field into JSON segments', () => {
+			const ids = Array.from({ length: 20000 }, (_, i) => `id-${i}`);
+			const { header, segments } = splitAuditBody(
+				{ action: 'bulk', affected_ids: ids },
+				{ limit: 16 * 1024 }
+			);
+
+			expect(header.chunked).toBe(true);
+			expect(header.body.action).toBe('bulk');
+			expect((header.body.affected_ids as { ref: string }).ref).toBe(
+				'body.affected_ids'
+			);
+
+			expect(segments.length).toBe(header.chunk_total);
+			segments.forEach((seg, i) => {
+				expect(seg.chunk_seq).toBe(i);
+				expect(seg.chunk_total).toBe(header.chunk_total);
+				expect(seg.chunk_field).toBe('body.affected_ids');
+				expect('body' in seg).toBe(true);
+				expect('chunk_part' in seg).toBe(false);
+			});
+
+			// Reconstruction: concatenate the array slices in order.
+			const rebuilt = segments.flatMap(
+				(seg) =>
+					(seg as { body: Record<string, unknown> }).body
+						.affected_ids as unknown[]
+			);
+			expect(rebuilt).toEqual(ids);
+		});
+
+		test('breaks an oversized scalar/blob field into text segments', () => {
+			const blob = 'x'.repeat(SAFE_LINE_BYTES + 5000);
+			const { header, segments } = splitAuditBody({
+				action: 'export',
+				result_csv: blob
+			});
+
+			expect(header.body.action).toBe('export');
+			expect((header.body.result_csv as { type: string }).type).toBe(
+				'string'
+			);
+
+			segments.forEach((seg) => {
+				expect(seg.chunk_field).toBe('body.result_csv');
+				expect('chunk_part' in seg).toBe(true);
+				expect('body' in seg).toBe(false);
+			});
+
+			// Reconstruction: concatenate the text fractions in order.
+			const rebuilt = segments
+				.map((seg) => (seg as { chunk_part: string }).chunk_part)
+				.join('');
+			expect(rebuilt).toBe(blob);
+		});
+
+		test('spreads first-level keys across lines on field-count overflow', () => {
+			const body: Record<string, number> = {};
+			for (let i = 0; i < 10; i++) body[`k${i}`] = i;
+
+			const { header, segments } = splitAuditBody(body, {
+				limit: 1024 * 1024,
+				maxFields: 4
+			});
+
+			expect(Object.keys(header.body).length).toBe(4);
+			const fieldSegments = segments.filter(
+				(s) => s.chunk_field === '(fields)'
+			);
+			expect(fieldSegments.length).toBe(2); // 4 + 4 + 2 = 10 keys
+			const seenKeys = new Set<string>(Object.keys(header.body));
+			for (const seg of fieldSegments) {
+				for (const key of Object.keys(
+					(seg as { body: Record<string, unknown> }).body
+				)) {
+					seenKeys.add(key);
+				}
+			}
+			expect(seenKeys.size).toBe(10);
+		});
+	});
+});


### PR DESCRIPTION
## O que / por quê

Implementa a issue #88 (RFC-OZLOGGER-AUDIT-001 §5, §8, §9): o **util reutilizável de quebra de logs de auditoria**.

Esta é a peça central da RFC. A quebra de registros grandes precisa ser feita **uma única vez, num único lugar**, e exportada de forma que qualquer outro projeto da DevOZ a use **exatamente da mesma maneira** (mesma entrada → mesma saída). Por isso o util é **puro e sem efeito colateral** — calcula a quebra e devolve dados; quem emite é o consumidor (issue #90).

## Mudanças

- **Novo** `lib/util/AuditChunk.ts` (função pura, não importa `Logger`, não escreve em stdout/console):
  - `splitAuditBody(body, opts)` → `{ header, segments[] }` — cabeçalho (skeleton com marcadores `{ ref, type, bytes, sha1 }`) + segmentos
  - `auditId()` — ULID de 26 chars (Crockford Base32), **zero dependências** (só `node:crypto`)
  - `byteLen`, `heavyMarker`, `splitFirstLevel`, `chunkArrayByBytes`, `chunkStringByBytes`, `countChunks`
  - `SAFE_LINE_BYTES = 200 * 1024` (margem sob o limite de 256KB do Victoria Logs)
- Exportado em `lib/index.ts` (ESM + CJS)
- `tests/auditChunk.test.ts` — testes unitários **isolados** (importam o util sem o `Logger`)
- Documentação: RFC + plano de tasks (#88–#91) em `docs/`

## Decisões adotadas (ver `docs/tasks/task-088-audit-chunk-util/Summary.md`)

- Divisão **por bytes** (`Buffer.byteLength`), nunca por contagem de itens
- Sequenciamento **global** de `chunk_seq`/`chunk_total` (alinhado à §8.1)
- `audit_id` via ULID inline zero-dep
- Array grande → segmentos JSON (`body`); escalar/blob → texto (`chunk_part`)
- Estouro por número de campos tratado (key-set splitting)

## Validação

- `tsc --noEmit` ✅
- Suíte completa: **248 testes** ✅ · cobertura global 96.84% stmts / 97.47% lines (gate ≥95%)
- `AuditChunk.ts`: 100% stmts / 100% lines · prova de ausência de efeito colateral (espião em `process.stdout`)

Parte da RFC-OZLOGGER-AUDIT-001. Próximas: #89 (assinatura `audit(_msg, body)`) e #90 (contingência), que consome este util.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
