### PR TITLE
OZLOGGER feat(audit)!: assinatura audit(_msg, body) e envelope limpo (#89)

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -19,6 +19,7 @@ import {
 	getProcessInformation,
 	getCircularReplacer
 } from './util/Helpers';
+import { auditId } from './util/AuditChunk';
 import { context, trace } from '@opentelemetry/api';
 
 /**
@@ -254,11 +255,15 @@ export class Logger implements LoggerMethods {
 	 * Factory method for the audit logging method.
 	 *
 	 * Audit is the VictoriaLogs ingestion entrypoint, so it is intentionally
-	 * stricter than the other log methods: it accepts exactly one value (of any
-	 * type). Passing a different number of arguments is a programming error and
-	 * throws, regardless of the active level, so it is caught in dev/test. An
-	 * oversized or unserializable body is a runtime data problem: it is reported
-	 * via this.error() and dropped, never crashing the host nor flooding
+	 * stricter than the other log methods: it has a fixed signature
+	 * audit(_msg, body). The first argument is the message string; the second
+	 * is the record body, written to a reserved envelope as `body` (assigned
+	 * whole, so caller keys can never overwrite metadata). Passing a different
+	 * number of arguments — or a non-string message — is a programming error
+	 * and throws, regardless of the active level, so it is caught in dev/test.
+	 * Every record carries a generated `audit_id`. An oversized or
+	 * unserializable body is a runtime data problem: it is reported via
+	 * this.error() and dropped, never crashing the host nor flooding
 	 * VictoriaLogs.
 	 *
 	 * @param   enabled  If the audit level is enabled for the current level.
@@ -266,25 +271,33 @@ export class Logger implements LoggerMethods {
 	 */
 	private buildAudit(enabled: boolean): AuditMethod {
 		const fn = (...args: unknown[]): void => {
-			// Audit takes exactly one value (of any type). Passing a different
-			// number of arguments is a programming error and throws, regardless
-			// of level, so it surfaces even when audit is disabled.
-			if (args.length !== 1) {
+			// Audit has a fixed arity of two (_msg, body). A different arity or
+			// a non-string message is a programming error and throws,
+			// regardless of level, so it surfaces even when audit is disabled.
+			if (args.length !== 2) {
 				throw new Error(
-					`audit() expects exactly one argument, but received ${args.length}`
+					`audit() expects exactly two arguments (_msg, body), but received ${args.length}`
 				);
 			}
 
-			const data = args[0];
+			const [msg, body] = args;
+
+			if (typeof msg !== 'string') {
+				throw new TypeError(
+					`audit() expects the first argument (_msg) to be a string, but received ${typeof msg}`
+				);
+			}
 
 			if (!enabled) return;
 
+			const id = auditId();
+
 			let serialized: string | undefined;
 			try {
-				serialized = JSON.stringify(data, getCircularReplacer());
+				serialized = JSON.stringify(body, getCircularReplacer());
 			} catch (e) {
 				this.error(
-					'[OZLogger] audit() could not serialize the provided value; record dropped',
+					`[OZLogger] audit() could not serialize the provided body; record dropped (audit_id=${id})`,
 					e
 				);
 				return;
@@ -295,12 +308,12 @@ export class Logger implements LoggerMethods {
 			const size = Buffer.byteLength(serialized ?? '', 'utf8');
 			if (size > DEFAULT_AUDIT_MAX_BYTES) {
 				this.error(
-					`[OZLogger] audit() body of ${size} bytes exceeds the safe limit of ${DEFAULT_AUDIT_MAX_BYTES} bytes for VictoriaLogs ingestion; record dropped`
+					`[OZLogger] audit() body of ${size} bytes exceeds the safe limit of ${DEFAULT_AUDIT_MAX_BYTES} bytes for VictoriaLogs ingestion; record dropped (audit_id=${id})`
 				);
 				return;
 			}
 
-			this.logger('AUDIT', data);
+			this.logger('AUDIT', { audit_id: id, _msg: msg, body });
 		};
 
 		const timeEnd = !enabled
@@ -310,7 +323,10 @@ export class Logger implements LoggerMethods {
 					return this;
 				}
 			: (id: string) => {
-					this.logger('AUDIT', `${id}: ${this.getTime(id)} ms`);
+					this.logger('AUDIT', {
+						audit_id: auditId(),
+						_msg: `${id}: ${this.getTime(id)} ms`
+					});
 					return this;
 				};
 
@@ -519,12 +535,15 @@ export class Logger implements LoggerMethods {
 	/**
 	 * Audit logging method.
 	 *
-	 * Entrypoint for VictoriaLogs ingestion. Accepts exactly one argument of any
-	 * type, written as-is to stdout. Passing a different number of arguments
-	 * throws; an oversized body (over {@link DEFAULT_AUDIT_MAX_BYTES}) is dropped
-	 * with an error.
+	 * Entrypoint for VictoriaLogs ingestion. Fixed signature audit(_msg, body):
+	 * the first argument is the message string, the second is the record body
+	 * (written whole under a reserved envelope, never as `body.0`). Every record
+	 * carries a generated `audit_id`. Passing a different number of arguments —
+	 * or a non-string message — throws; an oversized body (over
+	 * {@link DEFAULT_AUDIT_MAX_BYTES}) is dropped with an error.
 	 *
-	 * @param   data  The single value to be audited.
+	 * @param   _msg  The audit message (always a string).
+	 * @param   body  The record body (assigned whole).
 	 */
 	public audit: AuditMethod;
 

--- a/lib/format/json.ts
+++ b/lib/format/json.ts
@@ -81,6 +81,34 @@ export function json<TScope extends Logger>(
 		// isolate serialization and the underlying (possibly app-provided)
 		// client behind a try/catch.
 		try {
+			// Audit is the VictoriaLogs ingestion entrypoint and uses a clean,
+			// reserved envelope: the body is assigned whole (no `body.0`), no
+			// OpenTelemetry/process context is injected, and `_time` is always
+			// present. The caller passes only the audit-specific fields
+			// (audit_id, _msg, body and any chunk_* metadata); the envelope
+			// fields are fixed here, so caller keys (nested under `body`) can
+			// never overwrite metadata.
+			if (level === 'AUDIT') {
+				const fields =
+					typeof args[0] === 'object' && args[0] !== null
+						? (args[0] as Record<string, unknown>)
+						: { _msg: args[0] };
+
+				const entry = {
+					_time: new Date().toISOString(),
+					level /** @deprecated Use 'severityText' instead. */,
+					severityText: level,
+					severityNumber: LogLevels.audit,
+					tag,
+					...fields
+				};
+
+				logger.log(
+					paint[level](JSON.stringify(entry, getCircularReplacer()))
+				);
+				return;
+			}
+
 			const payload = toStructuredJsonLog.call(this, level, now, tag);
 
 			for (const arg of args) {

--- a/lib/format/text.ts
+++ b/lib/format/text.ts
@@ -32,14 +32,20 @@ export function text<TScope extends Logger>(
 					typeof args[0] === 'object' && args[0] !== null
 						? (args[0] as Record<string, unknown>)
 						: { _msg: args[0] };
+				const id =
+					fields.audit_id !== undefined
+						? stringify(fields.audit_id)
+						: '';
 				const msg =
 					fields._msg !== undefined ? stringify(fields._msg) : '';
 				const body =
 					fields.body !== undefined ? stringify(fields.body) : '';
 
+				// Keep the audit_id in text mode too, so a line can still be
+				// correlated with its JSON counterpart and the oversize ERROR.
 				logger.log(
 					paint[level](
-						`${now()}[${level}] ${tag ?? ''} ${msg} ${body}`.trimEnd()
+						`${now()}[${level}] ${tag ?? ''} ${id} ${msg} ${body}`.trimEnd()
 					)
 				);
 				return;

--- a/lib/format/text.ts
+++ b/lib/format/text.ts
@@ -24,6 +24,27 @@ export function text<TScope extends Logger>(
 		// isolate serialization and the underlying (possibly app-provided)
 		// client behind a try/catch.
 		try {
+			// Audit carries a structured envelope (audit_id, _msg, body, ...).
+			// In text mode we render the message followed by the serialized
+			// body so the line stays readable and never crashes.
+			if (level === 'AUDIT') {
+				const fields =
+					typeof args[0] === 'object' && args[0] !== null
+						? (args[0] as Record<string, unknown>)
+						: { _msg: args[0] };
+				const msg =
+					fields._msg !== undefined ? stringify(fields._msg) : '';
+				const body =
+					fields.body !== undefined ? stringify(fields.body) : '';
+
+				logger.log(
+					paint[level](
+						`${now()}[${level}] ${tag ?? ''} ${msg} ${body}`.trimEnd()
+					)
+				);
+				return;
+			}
+
 			const data = args.map((arg) => stringify(arg)).join(' ');
 
 			logger.log(paint[level](`${now()}[${level}] ${tag ?? ''} ${data}`));

--- a/lib/util/interface/LoggerMethods.ts
+++ b/lib/util/interface/LoggerMethods.ts
@@ -10,12 +10,14 @@ export type LogMethod = ((...args: unknown[]) => void) & {
  * Audit logging method.
  *
  * Unlike the other log methods, audit() is the entrypoint for VictoriaLogs
- * ingestion and accepts exactly ONE argument — of any type (object, string,
- * number, etc.). Calling it with a different number of arguments throws, since
- * that is a programming error and should surface in dev/test. The attached
- * timeEnd() preserves the timer helper available on the other methods.
+ * ingestion and has a FIXED signature audit(_msg, body): the first argument is
+ * always the message string, the second is the record body (assigned whole, so
+ * caller keys can never overwrite the envelope). Calling it with a different
+ * number of arguments — or a non-string message — throws, since that is a
+ * programming error and should surface in dev/test. The attached timeEnd()
+ * preserves the timer helper available on the other methods.
  */
-export type AuditMethod = ((data: unknown) => void) & {
+export type AuditMethod = ((_msg: string, body: unknown) => void) & {
 	timeEnd(id: string): Logger;
 };
 

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,4 +1,5 @@
 import { expect, describe, test, beforeEach, afterEach } from '@jest/globals';
+import { trace } from '@opentelemetry/api';
 import createLogger, { Logger } from '../lib';
 
 describe('audit (VictoriaLogs ingestion contract)', () => {
@@ -19,53 +20,126 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 	afterEach(() => {
 		delete process.env.OZLOGGER_OUTPUT;
 		delete process.env.OZLOGGER_LEVEL;
+		delete process.env.OZLOGGER_DATETIME;
 	});
 
-	describe('valid usage', () => {
-		test('writes a single JSON object as the audit body', () => {
-			logger.audit({ user: 'alice', action: 'login' });
+	describe('signature audit(_msg, body)', () => {
+		test('writes _msg, audit_id and the body assigned whole (no body.0)', () => {
+			logger.audit('alice login', { user: 'alice', action: 'login' });
 
 			expect(logged.length).toBe(1);
 			const output = JSON.parse(logged[0]);
 			expect(output.severityText).toBe('AUDIT');
-			expect(output.body['0']).toEqual({
-				user: 'alice',
-				action: 'login'
-			});
+			expect(output.severityNumber).toBe(12);
+			expect(output._msg).toBe('alice login');
+			expect(typeof output.audit_id).toBe('string');
+			expect(output.audit_id.length).toBeGreaterThan(0);
+			// Body is assigned whole — the `body.0` proxy is gone.
+			expect(output.body).toEqual({ user: 'alice', action: 'login' });
+			expect(output.body['0']).toBeUndefined();
+		});
+
+		test('a scalar body is the value itself', () => {
+			logger.audit('the answer', 42);
+
+			const output = JSON.parse(logged[0]);
+			expect(output.body).toBe(42);
+			expect(output._msg).toBe('the answer');
+		});
+
+		test('_time is always present (ISO) regardless of OZLOGGER_DATETIME', () => {
+			logger.audit('no datetime flag', { a: 1 });
+			const output = JSON.parse(logged[0]);
+			expect(typeof output._time).toBe('string');
+			expect(new Date(output._time).toISOString()).toBe(output._time);
 		});
 
 		test('serializes objects with circular references', () => {
 			const data: Record<string, unknown> = { id: 1 };
 			data.self = data;
 
-			expect(() => logger.audit(data)).not.toThrow();
+			expect(() => logger.audit('circular', data)).not.toThrow();
 			expect(logged.length).toBe(1);
 			expect(JSON.parse(logged[0]).severityText).toBe('AUDIT');
 		});
+	});
 
-		test('accepts a single value of any type (string, number, array)', () => {
-			logger.audit('a plain string');
-			logger.audit(42);
-			logger.audit([1, 2, 3]);
+	describe('envelope isolation (§6.3 / §6.4)', () => {
+		test('caller keys cannot overwrite reserved envelope fields', () => {
+			logger.audit('teste', {
+				a: 1,
+				LEVEL: 'override',
+				level: 'override',
+				tag: 'override',
+				audit_id: 'override'
+			});
 
-			expect(logged.length).toBe(3);
-			expect(JSON.parse(logged[0]).body['0']).toBe('a plain string');
-			expect(JSON.parse(logged[1]).body['0']).toBe(42);
-			expect(JSON.parse(logged[2]).body['0']).toEqual([1, 2, 3]);
+			const output = JSON.parse(logged[0]);
+			expect(output.level).toBe('AUDIT');
+			expect(output.tag).toBe('AUDIT-TEST');
+			expect(output.audit_id).not.toBe('override');
+			// The caller keys stay nested under body.
+			expect(output.body.LEVEL).toBe('override');
+			expect(output.body.level).toBe('override');
+			expect(output.body.tag).toBe('override');
+			expect(output.body.audit_id).toBe('override');
+		});
+
+		test('does not include pid/ppid/traceId/spanId even within an active span', () => {
+			const tracer = trace.getTracer('audit-test');
+			tracer.startActiveSpan('op', (span) => {
+				logger.audit('within span', { ok: true });
+				span.end();
+			});
+
+			const output = JSON.parse(logged[0]);
+			expect(output.pid).toBeUndefined();
+			expect(output.ppid).toBeUndefined();
+			expect(output.traceId).toBeUndefined();
+			expect(output.spanId).toBeUndefined();
+			expect(output.host).toBeUndefined();
+			expect(output.tenant).toBeUndefined();
+		});
+
+		test('does not auto-mask PII (email/cpf stay visible)', () => {
+			logger.audit('signup', {
+				email: 'alice@example.com',
+				cpf: '123.456.789-00'
+			});
+
+			const output = JSON.parse(logged[0]);
+			expect(output.body.email).toBe('alice@example.com');
+			expect(output.body.cpf).toBe('123.456.789-00');
 		});
 	});
 
 	describe('usage errors throw (programming mistakes)', () => {
 		test('throws when called with no arguments', () => {
 			// @ts-expect-error - testing invalid input
-			expect(() => logger.audit()).toThrow(/exactly one argument/);
+			expect(() => logger.audit()).toThrow(/exactly two arguments/);
 			expect(logged.length).toBe(0);
 		});
 
-		test('throws when called with more than one argument', () => {
+		test('throws when called with a single argument', () => {
 			// @ts-expect-error - testing invalid input
-			expect(() => logger.audit({ a: 1 }, { b: 2 })).toThrow(
-				/exactly one argument/
+			expect(() => logger.audit({ a: 1 })).toThrow(
+				/exactly two arguments/
+			);
+			expect(logged.length).toBe(0);
+		});
+
+		test('throws when called with more than two arguments', () => {
+			// @ts-expect-error - testing invalid input
+			expect(() => logger.audit('m', { a: 1 }, { b: 2 })).toThrow(
+				/exactly two arguments/
+			);
+			expect(logged.length).toBe(0);
+		});
+
+		test('throws when the message is not a string', () => {
+			// @ts-expect-error - testing invalid input
+			expect(() => logger.audit({ not: 'a string' }, {})).toThrow(
+				/first argument \(_msg\) to be a string/
 			);
 			expect(logged.length).toBe(0);
 		});
@@ -75,34 +149,34 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 			logged = [];
 
 			// @ts-expect-error - testing invalid input
-			expect(() => logger.audit('a', 'b')).toThrow(
-				/exactly one argument/
+			expect(() => logger.audit('a', 'b', 'c')).toThrow(
+				/exactly two arguments/
 			);
-			// A valid single value is simply not emitted while disabled.
-			expect(() => logger.audit({ ok: true })).not.toThrow();
+			// A valid call is simply not emitted while disabled.
+			expect(() => logger.audit('ok', { ok: true })).not.toThrow();
 			expect(logged.length).toBe(0);
 		});
 	});
 
 	describe('runtime data problems are dropped with an error (never crash)', () => {
-		test('drops an oversized body and logs an error', () => {
+		test('drops an oversized body and logs an error with the audit_id', () => {
 			const huge = { blob: 'x'.repeat(300 * 1024) };
 
-			expect(() => logger.audit(huge)).not.toThrow();
+			expect(() => logger.audit('oversize', huge)).not.toThrow();
 
 			// The audit record is dropped; only the error log is emitted.
 			expect(logged.length).toBe(1);
 			const output = JSON.parse(logged[0]);
 			expect(output.severityText).toBe('ERROR');
 			expect(output.body['0']).toContain('exceeds the safe limit');
+			expect(output.body['0']).toContain('audit_id=');
 		});
 
 		test('drops an unserializable body and logs an error', () => {
-			// BigInt is a valid Record value at the type level but cannot be
-			// serialized by JSON.stringify, so it fails at runtime.
+			// BigInt cannot be serialized by JSON.stringify, so it fails at runtime.
 			const bad = { value: BigInt(9007199254740991) };
 
-			expect(() => logger.audit(bad)).not.toThrow();
+			expect(() => logger.audit('bad', bad)).not.toThrow();
 
 			expect(logged.length).toBe(1);
 			const output = JSON.parse(logged[0]);
@@ -117,7 +191,9 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 			logger.audit.timeEnd('audit-op');
 
 			expect(logged.length).toBe(1);
-			expect(JSON.parse(logged[0]).severityText).toBe('AUDIT');
+			const output = JSON.parse(logged[0]);
+			expect(output.severityText).toBe('AUDIT');
+			expect(output._msg).toContain('audit-op:');
 		});
 
 		test('audit.timeEnd cleans up the timer when audit is disabled', () => {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -130,7 +130,7 @@ describe('JSON Formatter', () => {
 		});
 
 		test('audit level', () => {
-			logger.audit({ msg: 'audit msg' });
+			logger.audit('audit msg', { msg: 'audit msg' });
 			const output = JSON.parse(logged[0]);
 			expect(output.severityText).toBe('AUDIT');
 			expect(output.severityNumber).toBe(12);
@@ -194,6 +194,22 @@ describe('Text Formatter', () => {
 	test('should join multiple arguments with space', () => {
 		logger.info('one', 'two', 'three');
 		expect(logged[0]).toContain('one two three');
+	});
+
+	test('should render audit as message followed by the body', () => {
+		logger.audit('alice login', { user: 'alice' });
+		expect(logged.length).toBe(1);
+		expect(logged[0]).toContain('[AUDIT]');
+		expect(logged[0]).toContain('TEXT-TEST');
+		expect(logged[0]).toContain('alice login');
+		expect(logged[0]).toContain('alice');
+	});
+
+	test('should render audit timeEnd without throwing', () => {
+		logger.time('op');
+		expect(() => logger.audit.timeEnd('op')).not.toThrow();
+		expect(logged[0]).toContain('[AUDIT]');
+		expect(logged[0]).toContain('op:');
 	});
 });
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -197,12 +197,22 @@ describe('Text Formatter', () => {
 	});
 
 	test('should render audit as message followed by the body', () => {
-		logger.audit('alice login', { user: 'alice' });
+		logger.audit('signin', { account: 'alice' });
 		expect(logged.length).toBe(1);
 		expect(logged[0]).toContain('[AUDIT]');
 		expect(logged[0]).toContain('TEXT-TEST');
-		expect(logged[0]).toContain('alice login');
+		expect(logged[0]).toContain('signin');
+		// A body-only token proves the body half of the line is rendered
+		// (not just the message).
+		expect(logged[0]).toContain('account');
 		expect(logged[0]).toContain('alice');
+	});
+
+	test('should render a scalar audit body', () => {
+		logger.audit('the answer', 42);
+		expect(logged[0]).toContain('[AUDIT]');
+		expect(logged[0]).toContain('the answer');
+		expect(logged[0]).toContain('42');
 	});
 
 	test('should render audit timeEnd without throwing', () => {

--- a/tests/logger-core.test.ts
+++ b/tests/logger-core.test.ts
@@ -188,7 +188,7 @@ describe('Logger Core', () => {
 			logged = [];
 			logger.debug('no');
 			logger.info('no');
-			logger.audit({ m: 'no' });
+			logger.audit('no', { m: 'no' });
 			logger.warn('no');
 			expect(logged.length).toBe(0);
 			logger.error('yes');
@@ -202,7 +202,7 @@ describe('Logger Core', () => {
 			logged = [];
 			logger.debug('no');
 			logger.info('no');
-			logger.audit({ m: 'no' });
+			logger.audit('no', { m: 'no' });
 			logger.warn('no');
 			logger.error('no');
 			expect(logged.length).toBe(0);
@@ -215,7 +215,7 @@ describe('Logger Core', () => {
 			logger.debug('no'); // debug < audit
 			logger.info('no'); // info < audit
 			expect(logged.length).toBe(0);
-			logger.audit({ m: 'yes' });
+			logger.audit('yes', { m: 'yes' });
 			expect(logged.length).toBe(1);
 		});
 	});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -29,7 +29,7 @@ describe('OZLogger factory test suite.', () => {
 	test('logger must have audit method.', () => {
 		expect(typeof logger['audit'] === 'function').toBe(true);
 		expect(() =>
-			logger.audit({ message: 'audit message log' })
+			logger.audit('audit message log', { message: 'audit message log' })
 		).not.toThrow(Error);
 		logger.time('test');
 		expect(() => logger.audit.timeEnd('test')).not.toThrow(Error);


### PR DESCRIPTION
## O que / por quê

Implementa a issue #89 (RFC-OZLOGGER-AUDIT-001 §1, §2, §6, §14): a assinatura fixa `audit(_msg, body)` e o envelope de auditoria limpo.

> ⚠️ **Breaking change** na API do `audit()`. Empilhado sobre #88 (PR #92) — base desta PR é `feat/audit-chunk-util`.

Encerra o estilo de 1 argumento (e o campo `body.0`), define a mensagem de forma explícita (`_msg`) e isola o corpo do envelope.

## Mudanças

- **`lib/Logger.ts` (`buildAudit`):** aridade fixa **2** (`_msg`, `body`); lança em qualquer outra aridade e quando `_msg` não é string — mesmo com o nível desabilitado. Gera `audit_id` (ULID, via util da #88).
- **`lib/format/json.ts`:** caminho dedicado para AUDIT — `body` atribuído **inteiro** (fim do `body.0`), `_time` (ISO) **sempre** presente, **sem** `getContext()` (exclui `pid`/`ppid`/`traceId`/`spanId`/`host`/`tenant`), com `audit_id` e `_msg`. Mantém `severityText: 'AUDIT'` / `severityNumber: 12`. Os demais níveis seguem inalterados.
- **`lib/format/text.ts`:** modo texto renderiza `_msg` + corpo serializado para auditoria (não lança).
- **`lib/util/interface/LoggerMethods.ts`:** `AuditMethod` agora é `(_msg: string, body: unknown) => void`.
- Testes migrados para a nova assinatura (`audit.test.ts` reescrito; `format`, `logger`, `logger-core` ajustados).

## Isolamento de metadados (§6.3 / §6.4)

`audit('t', { LEVEL, level, tag, audit_id })` mantém todas as chaves do chamador **aninhadas em `body`**; o envelope (`level`, `tag`, `audit_id`) é fixo e não pode ser sobrescrito — garantido por construção (corpo atribuído inteiro, nunca espalhado). PII (`email`/`cpf`) **não** é mascarada no caminho de auditoria (§13).

## Nota de escopo

O corpo acima do limite ainda é **descartado com ERROR** (agora carregando o `audit_id`). A troca por **quebra/contingência** (`AUDIT_OVERSIZE`) é a issue #90, próxima do stack — consome o util da #88 e este envelope.

## Validação

- `tsc --noEmit` ✅
- Suíte completa: **256 testes** ✅ · cobertura global 96.92% stmts / 97.54% lines (gate ≥95%)
- `json.ts` e `text.ts`: 100% linhas

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
