### PR TITLE
OZLOGGER feat(audit): contingência de quebra + auditChunked + ERROR AUDIT_OVERSIZE (#90)

### DIFF
--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -351,7 +351,13 @@ export class Logger implements LoggerMethods {
 			limit: SAFE_LINE_BYTES
 		});
 
-		this.error(
+		// The AUDIT_OVERSIZE ERROR is mandatory on every break (RFC §8): emit it
+		// through the underlying wrapper directly, NOT via this.error(), so it is
+		// never suppressed by the active log level (e.g. at 'critical'/'quiet').
+		// Without this, a break could ship chunk lines while silently dropping
+		// the high-visibility alert that signals the oversize must be fixed.
+		this.logger(
+			'ERROR',
 			`[OZLogger] AUDIT_OVERSIZE audit_id=${id}: the audit record exceeded ` +
 				`the ${SAFE_LINE_BYTES} bytes safe line limit and was broken into ` +
 				`${header.chunk_total} part(s). This is a contingency, not a feature; ` +

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -17,9 +17,10 @@ import {
 	output,
 	host,
 	getProcessInformation,
-	getCircularReplacer
+	getCircularReplacer,
+	isJsonObject
 } from './util/Helpers';
-import { auditId } from './util/AuditChunk';
+import { auditId, splitAuditBody, SAFE_LINE_BYTES } from './util/AuditChunk';
 import { context, trace } from '@opentelemetry/api';
 
 /**
@@ -31,17 +32,6 @@ const DEFAULT_TIMER_TTL = 600000;
  * Default timer cleanup interval in milliseconds (1 minute).
  */
 const DEFAULT_TIMER_GC_INTERVAL = 60000;
-
-/**
- * Maximum serialized size, in bytes, allowed for an audit body.
- *
- * VictoriaLogs skips log lines larger than its `-insert.maxLineSizeBytes`
- * (256KB by default) during ingestion, and handles records approaching the
- * hardcoded 2MB ceiling inefficiently. We cap the audit body at that 256KB
- * line limit so a single audit entry never floods VictoriaLogs; bodies above
- * it are dropped with an error.
- */
-const DEFAULT_AUDIT_MAX_BYTES = 256 * 1024;
 
 /**
  * Logger module class.
@@ -306,10 +296,11 @@ export class Logger implements LoggerMethods {
 			// JSON.stringify yields undefined for values such as undefined or
 			// functions; treat those as empty for the size check.
 			const size = Buffer.byteLength(serialized ?? '', 'utf8');
-			if (size > DEFAULT_AUDIT_MAX_BYTES) {
-				this.error(
-					`[OZLogger] audit() body of ${size} bytes exceeds the safe limit of ${DEFAULT_AUDIT_MAX_BYTES} bytes for VictoriaLogs ingestion; record dropped (audit_id=${id})`
-				);
+			if (size > SAFE_LINE_BYTES) {
+				// Contingency, not a feature: rather than silently dropping the
+				// record, break it into safe-sized lines and raise a loud ERROR
+				// so the oversize is fixed at the source (audit the intent).
+				this.emitOversizeAudit(msg, body, id);
 				return;
 			}
 
@@ -331,6 +322,85 @@ export class Logger implements LoggerMethods {
 				};
 
 		return Object.assign(fn, { timeEnd });
+	}
+
+	/**
+	 * Breaks an oversized audit record into safe-sized lines and emits the
+	 * mandatory ERROR.
+	 *
+	 * This is a contingency, not a feature (RFC §8): it exists only so a large
+	 * record is never silently lost. The break is delegated to the shared
+	 * {@link splitAuditBody} util — so every place that breaks audit logs does
+	 * it identically — and produces a header line (the full first level, with
+	 * oversized values replaced by markers) plus segment lines, all correlated
+	 * by the same `audit_id`. A high-visibility ERROR carrying the `audit_id`
+	 * is always raised so the oversize is corrected at the source.
+	 *
+	 * @param   msg   The audit message.
+	 * @param   body  The oversized body.
+	 * @param   id    The audit_id correlating every emitted line.
+	 */
+	private emitOversizeAudit(msg: string, body: unknown, id: string): void {
+		// splitAuditBody works on the first level of an object; a non-object
+		// body is wrapped so it can still be broken without losing data.
+		const input = isJsonObject(body)
+			? (body as Record<string, unknown>)
+			: { value: body };
+
+		const { header, segments } = splitAuditBody(input, {
+			limit: SAFE_LINE_BYTES
+		});
+
+		this.error(
+			`[OZLogger] AUDIT_OVERSIZE audit_id=${id}: the audit record exceeded ` +
+				`the ${SAFE_LINE_BYTES} bytes safe line limit and was broken into ` +
+				`${header.chunk_total} part(s). This is a contingency, not a feature; ` +
+				`reduce the volume at the source (audit the intent, RFC §7).`
+		);
+
+		this.logger('AUDIT', { audit_id: id, _msg: msg, ...header });
+
+		for (const segment of segments) {
+			this.logger('AUDIT', { audit_id: id, ...segment });
+		}
+	}
+
+	/**
+	 * Temporary contingency entrypoint for the import tool.
+	 *
+	 * @deprecated Not a feature. Created so the import tool — which still emits
+	 * large records (resolved identifier lists) — does not lose data silently
+	 * while it is not yet auditing the intent (RFC §7, §9). It breaks an
+	 * oversized body into audit lines of up to ~200KB using the same shared
+	 * {@link splitAuditBody} util as `audit()`, always raising an
+	 * AUDIT_OVERSIZE ERROR. A body that already fits takes the normal
+	 * single-line path. Remove this once the import tool audits the intent.
+	 *
+	 * @param   _msg  The audit message (always a string).
+	 * @param   body  The record body.
+	 */
+	public auditChunked(_msg: string, body: Record<string, unknown>): void {
+		const id = auditId();
+
+		let serialized: string | undefined;
+		try {
+			serialized = JSON.stringify(body, getCircularReplacer());
+		} catch (e) {
+			this.error(
+				`[OZLogger] auditChunked() could not serialize the provided body; record dropped (audit_id=${id})`,
+				e
+			);
+			return;
+		}
+
+		const size = Buffer.byteLength(serialized ?? '', 'utf8');
+		if (size <= SAFE_LINE_BYTES) {
+			// It fits: normal single-line path, no break, no ERROR.
+			this.logger('AUDIT', { audit_id: id, _msg, body });
+			return;
+		}
+
+		this.emitOversizeAudit(_msg, body, id);
 	}
 
 	/**
@@ -539,8 +609,9 @@ export class Logger implements LoggerMethods {
 	 * the first argument is the message string, the second is the record body
 	 * (written whole under a reserved envelope, never as `body.0`). Every record
 	 * carries a generated `audit_id`. Passing a different number of arguments —
-	 * or a non-string message — throws; an oversized body (over
-	 * {@link DEFAULT_AUDIT_MAX_BYTES}) is dropped with an error.
+	 * or a non-string message — throws. An oversized body (over
+	 * {@link SAFE_LINE_BYTES}) is not dropped: it is broken into safe-sized lines
+	 * with a loud AUDIT_OVERSIZE ERROR (contingency, see {@link auditChunked}).
 	 *
 	 * @param   _msg  The audit message (always a string).
 	 * @param   body  The record body (assigned whole).

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -159,19 +159,6 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 	});
 
 	describe('runtime data problems are dropped with an error (never crash)', () => {
-		test('drops an oversized body and logs an error with the audit_id', () => {
-			const huge = { blob: 'x'.repeat(300 * 1024) };
-
-			expect(() => logger.audit('oversize', huge)).not.toThrow();
-
-			// The audit record is dropped; only the error log is emitted.
-			expect(logged.length).toBe(1);
-			const output = JSON.parse(logged[0]);
-			expect(output.severityText).toBe('ERROR');
-			expect(output.body['0']).toContain('exceeds the safe limit');
-			expect(output.body['0']).toContain('audit_id=');
-		});
-
 		test('drops an unserializable body and logs an error', () => {
 			// BigInt cannot be serialized by JSON.stringify, so it fails at runtime.
 			const bad = { value: BigInt(9007199254740991) };
@@ -182,6 +169,108 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 			const output = JSON.parse(logged[0]);
 			expect(output.severityText).toBe('ERROR');
 			expect(output.body['0']).toContain('could not serialize');
+		});
+	});
+
+	describe('oversize contingency (RFC §8): break, never drop', () => {
+		test('breaks an oversized array field into correlated lines + ERROR', () => {
+			const ids = Array.from({ length: 60000 }, (_, i) => `id-${i}`);
+
+			expect(() =>
+				logger.audit('bulk.update', {
+					action: 'update',
+					affected_ids: ids
+				})
+			).not.toThrow();
+
+			const records = logged.map((l) => JSON.parse(l));
+			const error = records.find((r) => r.severityText === 'ERROR');
+			const header = records.find(
+				(r) => r.severityText === 'AUDIT' && r.chunked
+			);
+			const segments = records.filter(
+				(r) => r.severityText === 'AUDIT' && r.chunk_field !== undefined
+			);
+
+			// Nothing is dropped: header + segments + exactly one ERROR.
+			expect(header).toBeDefined();
+			expect(error).toBeDefined();
+			expect(
+				records.filter((r) => r.severityText === 'ERROR').length
+			).toBe(1);
+			expect(segments.length).toBeGreaterThan(0);
+
+			// The ERROR is the AUDIT_OVERSIZE signal carrying the audit_id (§11d).
+			expect(error.body['0']).toContain('AUDIT_OVERSIZE');
+			expect(error.body['0']).toContain(`audit_id=${header.audit_id}`);
+			expect(error.body['0']).toContain('§7');
+
+			// Header keeps the first level inline; the heavy field is a marker.
+			expect(header._msg).toBe('bulk.update');
+			expect(header.body.action).toBe('update');
+			expect(header.body.affected_ids.ref).toBe('body.affected_ids');
+			expect(header.chunk_total).toBe(segments.length);
+
+			// Correlation + sequencing; segments carry no _msg.
+			segments.forEach((seg) => {
+				expect(seg.audit_id).toBe(header.audit_id);
+				expect(seg.chunk_field).toBe('body.affected_ids');
+				expect(seg._msg).toBeUndefined();
+				expect(seg.pid).toBeUndefined();
+				expect(seg.traceId).toBeUndefined();
+			});
+
+			// Reconstruction by chunk_field rebuilds the original array.
+			const rebuilt = segments
+				.sort((a, b) => a.chunk_seq - b.chunk_seq)
+				.flatMap((seg) => seg.body.affected_ids);
+			expect(rebuilt).toEqual(ids);
+		});
+
+		test('breaks an oversized scalar/blob field into text segments', () => {
+			const blob = 'x'.repeat(260 * 1024);
+
+			logger.audit('export', { result_csv: blob });
+
+			const records = logged.map((l) => JSON.parse(l));
+			const segments = records.filter(
+				(r) => r.severityText === 'AUDIT' && r.chunk_part !== undefined
+			);
+			expect(segments.length).toBeGreaterThan(0);
+
+			const rebuilt = segments
+				.sort((a, b) => a.chunk_seq - b.chunk_seq)
+				.map((seg) => seg.chunk_part)
+				.join('');
+			expect(rebuilt).toBe(blob);
+		});
+	});
+
+	describe('auditChunked (deprecated import contingency, RFC §9)', () => {
+		test('a body that fits takes the normal single-line path (no chunks, no ERROR)', () => {
+			logger.auditChunked('import.small', { count: 3 });
+
+			expect(logged.length).toBe(1);
+			const output = JSON.parse(logged[0]);
+			expect(output.severityText).toBe('AUDIT');
+			expect(output._msg).toBe('import.small');
+			expect(output.body).toEqual({ count: 3 });
+			expect(output.chunked).toBeUndefined();
+			expect(output.chunk_field).toBeUndefined();
+		});
+
+		test('an oversized body is broken using the same util + ERROR', () => {
+			const ids = Array.from({ length: 60000 }, (_, i) => `id-${i}`);
+
+			logger.auditChunked('import.bulk', { ids });
+
+			const records = logged.map((l) => JSON.parse(l));
+			expect(records.some((r) => r.chunked)).toBe(true);
+			expect(
+				records.filter((r) => r.severityText === 'ERROR').length
+			).toBe(1);
+			const error = records.find((r) => r.severityText === 'ERROR');
+			expect(error.body['0']).toContain('AUDIT_OVERSIZE');
 		});
 	});
 

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -265,12 +265,37 @@ describe('audit (VictoriaLogs ingestion contract)', () => {
 			logger.auditChunked('import.bulk', { ids });
 
 			const records = logged.map((l) => JSON.parse(l));
-			expect(records.some((r) => r.chunked)).toBe(true);
+			const header = records.find((r) => r.chunked);
+			expect(header).toBeDefined();
 			expect(
 				records.filter((r) => r.severityText === 'ERROR').length
 			).toBe(1);
 			const error = records.find((r) => r.severityText === 'ERROR');
 			expect(error.body['0']).toContain('AUDIT_OVERSIZE');
+
+			// Reconstruction: the broken array round-trips from its segments.
+			const rebuilt = records
+				.filter((r) => r.chunk_field === 'body.ids')
+				.sort((a, b) => a.chunk_seq - b.chunk_seq)
+				.flatMap((seg) => seg.body.ids);
+			expect(rebuilt).toEqual(ids);
+		});
+
+		test('still emits the mandatory AUDIT_OVERSIZE ERROR even at quiet level', () => {
+			// The ERROR must never be gated away by the active level — it is the
+			// signal that a break happened (RFC §8). Chunk lines emit regardless.
+			logger.changeLevel('quiet');
+			logged = [];
+
+			logger.auditChunked('import.bulk', {
+				ids: Array.from({ length: 60000 }, (_, i) => `id-${i}`)
+			});
+
+			const records = logged.map((l) => JSON.parse(l));
+			const errors = records.filter((r) => r.severityText === 'ERROR');
+			expect(errors.length).toBe(1);
+			expect(errors[0].body['0']).toContain('AUDIT_OVERSIZE');
+			expect(records.some((r) => r.chunked)).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## O que / por quê

Implementa a issue #90 (RFC-OZLOGGER-AUDIT-001 §1.3, §3, §8, §9, §13): a **contingência de quebra** que substitui o descarte silencioso de registros grandes.

> Empilhado sobre #89 (PR #93) → #88 (PR #92). Base desta PR é `feat/audit-signature`.

## Mudanças (`lib/Logger.ts`)

- O ramo de oversize do `audit()` **deixa de descartar**: quando o registro passa de `SAFE_LINE_BYTES` (~200KB), ele é **quebrado** via o util compartilhado `splitAuditBody()` (issue #88) e emite cabeçalho + segmentos correlacionados pelo `audit_id`.
- **Sempre** emite um ERROR de alta visibilidade `AUDIT_OVERSIZE` com o `audit_id`, a contagem de partes e a referência à §7 (corrigir na origem) — casa com a consulta LogsQL §11d.
- Novo método privado `emitOversizeAudit(msg, body, id)` — único ponto de emissão da quebra, reutilizado pelos dois entrypoints (sem fork).
- Novo método **`auditChunked(_msg, body)`** `@deprecated` (RFC §9), para a ferramenta de importação: corpo que cabe → linha única normal; corpo grande → mesma contingência + ERROR. A ser removido quando a importação auditar por intenção.
- Remove a constante `DEFAULT_AUDIT_MAX_BYTES` (o gatilho agora é `SAFE_LINE_BYTES`); JSDoc atualizado (quebra, não descarte).

## Garantia "quebra igual em todo lugar"

`audit()` e `auditChunked()` chamam **o mesmo** `splitAuditBody()` e o mesmo `emitOversizeAudit()`. Não há lógica duplicada — exatamente o requisito do produto.

## Comportamento das linhas

- **Cabeçalho:** primeiro nível inline; valor pesado vira marcador `{ ref, type, bytes, sha1 }`; `chunked: true`, `chunk_total`, `_msg`.
- **Segmentos array:** `body: { [campo]: <fração> }` (consultável por `json_array_contains_any`).
- **Segmentos escalar/blob:** `chunk_part` (texto, reconstruído por concatenação).
- Todas as linhas herdam o envelope limpo da #89 (sem `pid`/`ppid`/`traceId`/`spanId`; `_time`; `severityNumber 12`; sem `body.0`).
- Sequenciamento **global** (`chunk_seq`/`chunk_total`), reconstrução por `chunk_field`.

## Validação

- `tsc --noEmit` ✅
- Suíte completa: **259 testes** ✅ · cobertura global 96.68% stmts / 97.26% lines (gate ≥95%)
- Testes novos: quebra de array + ERROR + correlação + reconstrução; quebra de blob; `auditChunked` (caminho que cabe / que quebra)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
