### PR TITLE
chore: habilita análise SonarQube (I9OZMAP-273)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,9 +1,12 @@
 # Repository secrets:
 # SONAR_HOST_URL
 # SONAR_TOKEN
+# GH_PAT (checkout do ozflow)
 #
-# A action sonarqube-scan vem do ozflow (privado) direto via `uses:`;
-# requer "Actions access: organization" habilitado no repositório ozflow.
+# Este repositório é PÚBLICO: repo público não resolve action de repo privado
+# via `uses:` (o Actions access de organização só vale entre repos privados),
+# então o ozflow é baixado via checkout autenticado com GH_PAT, como no ozmap.
+# PRs de fork não recebem secrets — o scan só roda em branches internas.
 
 name: SonarQube Analysis
 
@@ -92,9 +95,21 @@ jobs:
           restore-keys: |
             sonar-scanner-cache-
 
+      - name: Fetch OzFlow
+        if: steps.scopes.outputs.code == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ozmap/ozflow
+          ref: main
+          token: ${{ secrets.GH_PAT }}
+          path: .github/actions/ozflow
+          sparse-checkout: |
+            actions/sonarqube-scan/
+          sparse-checkout-cone-mode: false
+
       - name: Run SonarQube Analysis
         if: steps.scopes.outputs.code == 'true'
-        uses: ozmap/ozflow/actions/sonarqube-scan@main
+        uses: ./.github/actions/ozflow/actions/sonarqube-scan
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,125 @@
+# Repository secrets:
+# SONAR_HOST_URL
+# SONAR_TOKEN
+#
+# A action sonarqube-scan vem do ozflow (privado) direto via `uses:`;
+# requer "Actions access: organization" habilitado no repositório ozflow.
+
+name: SonarQube Analysis
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  push:
+    branches:
+      - develop
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  sonarqube:
+    name: Run SonarQube Analysis
+    runs-on: ubuntu-latest
+    env:
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # PR que só altera docs/workflows não roda dependências, testes nem scan.
+      # Em push na develop tudo roda.
+      - name: Detect changed scopes
+        id: scopes
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          if git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -qvE '^(\.github/|docs/|.*\.md$)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pnpm
+        if: steps.scopes.outputs.code == 'true'
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        if: steps.scopes.outputs.code == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.scopes.outputs.code == 'true'
+        run: pnpm install
+
+      # Gera coverage/lcov.info para o Sonar (sonar.javascript.lcov.reportPaths).
+      # Não bloqueia o scan: sem lcov o gate acusa cobertura ausente no new code.
+      - name: Run tests with coverage
+        if: steps.scopes.outputs.code == 'true'
+        run: pnpm test
+        timeout-minutes: 10
+        continue-on-error: true
+
+      # Com node_modules presente, o analisador TS carrega o grafo de tipos das
+      # dependências e o processo Node estoura a memória do runner.
+      # O scan não precisa de node_modules; sem ele a análise fica leve.
+      - name: Remove node_modules before scan
+        if: steps.scopes.outputs.code == 'true'
+        run: rm -rf node_modules
+
+      # Cache do scanner (plugins + runtime Node do analisador), preenchido pelo
+      # scan.sh do ozflow; chave rolante para restaurar sempre o mais recente.
+      - name: Restore scanner cache
+        if: steps.scopes.outputs.code == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: .sonar-scanner-cache
+          key: sonar-scanner-cache-${{ github.run_id }}
+          restore-keys: |
+            sonar-scanner-cache-
+
+      - name: Run SonarQube Analysis
+        if: steps.scopes.outputs.code == 'true'
+        uses: ozmap/ozflow/actions/sonarqube-scan@main
+        with:
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          sonar-host: ${{ secrets.SONAR_HOST_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          paths: '["./"]'
+
+      # Só persiste cache com conteúdo: um scan abortado antes de baixar o JRE
+      # deixa o diretório vazio e, pela chave rolante, esse cache passaria a ser
+      # restaurado por todos os runs seguintes. Só o push na develop grava: o PR
+      # reaproveita esse cache sem subir uma cópia por run.
+      # Checagem via shell em vez de hashFiles(): o container do scanner deixa
+      # arquivos sem permissão de leitura para o runner e hashFiles() aborta o
+      # job inteiro; o chown também garante que o tar do actions/cache leia tudo.
+      - name: Check scanner cache content
+        if: always() && github.event_name == 'push' && steps.scopes.outputs.code == 'true'
+        id: scanner-cache
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" .sonar-scanner-cache 2>/dev/null || true
+          if [ -n "$(ls -A .sonar-scanner-cache/cache 2>/dev/null)" ]; then
+            echo "has-content=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save scanner cache
+        if: always() && steps.scanner-cache.outputs.has-content == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .sonar-scanner-cache
+          key: sonar-scanner-cache-${{ github.run_id }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=ozlogger
+sonar.projectName=OZlogger
+sonar.sources=lib/
+sonar.tests=tests/
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=tests/**/*
+sonar.javascript.node.maxspace=4096
+sonar.projectVersion=0.3.1


### PR DESCRIPTION
Task: [I9OZMAP-273](https://ozmap.atlassian.net/browse/I9OZMAP-273)

## Resumo
Habilita análise SonarQube no logger, replicando o fluxo dos demais projetos da org (ozmap/ozwarehouse/centraozconfig/ozrender):

- `sonar-project.properties`: projeto `ozlogger`, fontes em `lib/`, testes em `tests/`, cobertura via `coverage/lcov.info` (o jest já gera com `collectCoverage`).
- `.github/workflows/sonar.yml`: análise em PRs e push na `develop`; instala com pnpm 9 + Node 20 (mesmo setup do `ci.yml`), roda `pnpm test` para gerar cobertura (não bloqueante), remove `node_modules` antes do scan e usa a action `sonarqube-scan` do ozflow, que comenta o resultado do Quality Gate no PR. PRs que só mudam docs/workflows pulam o scan.

Como este repositório é **público**, o ozflow (privado) é baixado via checkout autenticado com `GH_PAT` — repo público não resolve action de repo privado via `uses:`, ao contrário dos demais projetos. Secrets não são expostos a PRs de fork, então o scan roda apenas em branches internas.

## Já provisionado (fora deste diff)
- Projeto `ozlogger` criado em https://sonarqube.ozmap.com (gate "ozmap way", new code 30 dias, main branch `develop`).
- Binding DevOps com `ozmap/logger` para decoração de PRs.
- Token de análise `ci-ozlogger` + secrets `SONAR_HOST_URL`, `SONAR_TOKEN` e `GH_PAT` no repositório.

## Validação
Workflow executado de ponta a ponta neste PR: dependências instaladas, cobertura gerada, scan concluído e Quality Gate **Passed**, com comentário automático e análise em https://sonarqube.ozmap.com/dashboard?id=ozlogger&pullRequest=110

Após o merge, o push na `develop` alimenta a branch principal no Sonar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[I9OZMAP-273]: https://ozmap.atlassian.net/browse/I9OZMAP-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ